### PR TITLE
Reduce number of exact homes computed

### DIFF
--- a/Cocoon/settings/Global_Config.py
+++ b/Cocoon/settings/Global_Config.py
@@ -35,7 +35,7 @@ HYBRID_WEIGHT_CHOICES = (
 # Homes with a commute of 10-80 will be accepted. This is to account for the difference of commute
 # within a given zip code
 approximate_commute_range = 20
-number_of_exact_commutes_computed = 25  # number of homes that the exact commute is calculated
+number_of_exact_commutes_computed = 24  # number of homes that the exact commute is calculated
 DEFAULT_COMMUTE_TYPE = "Driving"
 
 # Google distance matrix values

--- a/Cocoon/settings/Global_Config.py
+++ b/Cocoon/settings/Global_Config.py
@@ -34,8 +34,8 @@ HYBRID_WEIGHT_CHOICES = (
 # This is the acceptable range for an apartment. So if the user selected a commute of 30 - 60 minutes
 # Homes with a commute of 10-80 will be accepted. This is to account for the difference of commute
 # within a given zip code
-approximate_commute_range = 25
-number_of_exact_commutes_computed = 20  # number of homes that the exact commute is calculated
+approximate_commute_range = 20
+number_of_exact_commutes_computed = 25  # number of homes that the exact commute is calculated
 DEFAULT_COMMUTE_TYPE = "Driving"
 
 # Google distance matrix values

--- a/Cocoon/settings/Global_Config.py
+++ b/Cocoon/settings/Global_Config.py
@@ -34,8 +34,8 @@ HYBRID_WEIGHT_CHOICES = (
 # This is the acceptable range for an apartment. So if the user selected a commute of 30 - 60 minutes
 # Homes with a commute of 10-80 will be accepted. This is to account for the difference of commute
 # within a given zip code
-approximate_commute_range = 20
-number_of_exact_commutes_computed = 50  # number of homes that the exact commute is calculated
+approximate_commute_range = 25
+number_of_exact_commutes_computed = 20  # number of homes that the exact commute is calculated
 DEFAULT_COMMUTE_TYPE = "Driving"
 
 # Google distance matrix values


### PR DESCRIPTION
50 is too larger and makes the computation longer. 24 will be sufficient. Also 24 is important because with one origin it will make the number of elements 25 which will mean only 1 request is needed