### PR TITLE
Issue 122 load by survey name

### DIFF
--- a/cocoon/survey/admin.py
+++ b/cocoon/survey/admin.py
@@ -15,7 +15,7 @@ class AddressInLine(admin.StackedInline):
 
 
 class RentingSurveyModelAdmin(admin.ModelAdmin):
-    readonly_fields = ("created_survey", 'id',)
+    readonly_fields = ("created_survey", 'id', 'slug')
     # noinspection SpellCheckingInspection
     inlines = [AddressInLine]
     fieldsets = (
@@ -24,7 +24,7 @@ class RentingSurveyModelAdmin(admin.ModelAdmin):
                                'max_bathrooms_survey', )}),
         ('Interior Amenities',
          {'fields': ('air_conditioning_survey', 'interior_washer_dryer_survey',)}),
-        ('Created', {'fields': ('created_survey', 'id',)}),
+        ('Created', {'fields': ('created_survey', 'id', 'slug')}),
     )
     list_display = ('name', 'user_profile_survey', )
     list_filter = ['user_profile_survey']

--- a/cocoon/survey/admin.py
+++ b/cocoon/survey/admin.py
@@ -15,7 +15,7 @@ class AddressInLine(admin.StackedInline):
 
 
 class RentingSurveyModelAdmin(admin.ModelAdmin):
-    readonly_fields = ("created_survey", 'id', 'slug')
+    readonly_fields = ("created_survey", 'id', 'url')
     # noinspection SpellCheckingInspection
     inlines = [AddressInLine]
     fieldsets = (
@@ -24,7 +24,7 @@ class RentingSurveyModelAdmin(admin.ModelAdmin):
                                'max_bathrooms_survey', )}),
         ('Interior Amenities',
          {'fields': ('air_conditioning_survey', 'interior_washer_dryer_survey',)}),
-        ('Created', {'fields': ('created_survey', 'id', 'slug')}),
+        ('Created', {'fields': ('created_survey', 'id', 'url')}),
     )
     list_display = ('name', 'user_profile_survey', )
     list_filter = ['user_profile_survey']

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -299,9 +299,10 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInfo
 
         # Since slugs need to be unique and the survey name generates the slug, make sure that the new slug
         #   will not conflict with a current survey. If it does, force them to choose a new name.
-        if self.user.userProfile.rentingsurveymodel_set.filter(slug=slugify(current_form['name_survey'])).exists():
-            self.add_error('name_survey', "You already have a very similar name, please choose a more unique name")
-            valid = False
+        if 'name_survey' in self.changed_data:
+            if self.user.userProfile.rentingsurveymodel_set.filter(slug=slugify(current_form['name_survey'])).exists():
+                self.add_error('name_survey', "You already have a very similar name, please choose a more unique name")
+                valid = False
 
         return valid
 

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -261,7 +261,7 @@ class RentSurveyForm(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformat
     class Meta:
         model = RentingSurveyModel
         # Make sure to set the name later, in the survey result if they want to save the result
-        exclude = ["user_profile_survey", 'survey_type_survey', "name_survey", "survey_url", ]
+        exclude = ["user_profile_survey", 'survey_type_survey', "name_survey", "url", ]
 
 
 class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformationForm,

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -308,7 +308,7 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInfo
 
     class Meta:
         model = RentingSurveyModel
-        exclude = ["user_profile_survey", 'survey_type_survey', 'survey_url']
+        exclude = ["user_profile_survey", 'survey_type_survey', 'url']
 
 
 class CommuteInformationForm(ModelForm):

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -261,7 +261,7 @@ class RentSurveyForm(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformat
     class Meta:
         model = RentingSurveyModel
         # Make sure to set the name later, in the survey result if they want to save the result
-        exclude = ["user_profile_survey", 'survey_type_survey', "name_survey", "slug", ]
+        exclude = ["user_profile_survey", 'survey_type_survey', "name_survey", "survey_url", ]
 
 
 class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformationForm,
@@ -300,7 +300,7 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInfo
         # Since slugs need to be unique and the survey name generates the slug, make sure that the new slug
         #   will not conflict with a current survey. If it does, force them to choose a new name.
         if 'name_survey' in self.changed_data:
-            if self.user.userProfile.rentingsurveymodel_set.filter(slug=slugify(current_form['name_survey'])).exists():
+            if self.user.userProfile.rentingsurveymodel_set.filter(url=slugify(current_form['name_survey'])).exists():
                 self.add_error('name_survey', "You already have a very similar name, please choose a more unique name")
                 valid = False
 
@@ -308,7 +308,7 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInfo
 
     class Meta:
         model = RentingSurveyModel
-        exclude = ["user_profile_survey", 'survey_type_survey', 'slug']
+        exclude = ["user_profile_survey", 'survey_type_survey', 'survey_url']
 
 
 class CommuteInformationForm(ModelForm):

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -260,7 +260,7 @@ class RentSurveyForm(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformat
     class Meta:
         model = RentingSurveyModel
         # Make sure to set the name later, in the survey result if they want to save the result
-        exclude = ["user_profile_survey", 'survey_type_survey', "name_survey", ]
+        exclude = ["user_profile_survey", 'survey_type_survey', "name_survey", "slug", ]
 
 
 class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformationForm,
@@ -305,7 +305,7 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInfo
 
     class Meta:
         model = RentingSurveyModel
-        exclude = ["user_profile_survey", 'survey_type_survey']
+        exclude = ["user_profile_survey", 'survey_type_survey', 'slug']
 
 
 class CommuteInformationForm(ModelForm):

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -1,6 +1,7 @@
 # Django modules
 from django import forms
 from django.forms import ModelForm
+from django.utils.text import slugify
 
 # Survey models
 from cocoon.survey.models import RentingSurveyModel, HomeInformationModel, CommuteInformationModel, RentingDestinationsModel, \
@@ -296,9 +297,10 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInfo
         # will cause a key error
         current_form = self.cleaned_data.copy()
 
-        # Make sure the user cannot create a survey with the same name
-        if self.user.userProfile.rentingsurveymodel_set.filter(name_survey=current_form['name_survey']).exists():
-            self.add_error('name_survey', "Survey with that name already exists")
+        # Since slugs need to be unique and the survey name generates the slug, make sure that the new slug
+        #   will not conflict with a current survey. If it does, force them to choose a new name.
+        if self.user.userProfile.rentingsurveymodel_set.filter(slug=slugify(current_form['name_survey'])).exists():
+            self.add_error('name_survey', "You already have a very similar name, please choose a more unique name")
             valid = False
 
         return valid

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -261,7 +261,11 @@ class RentSurveyForm(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformat
     class Meta:
         model = RentingSurveyModel
         # Make sure to set the name later, in the survey result if they want to save the result
-        exclude = ["user_profile_survey", 'survey_type_survey', "name_survey", "url", ]
+        fields = ["num_bedrooms_survey", "max_bathrooms_survey", "min_bathrooms_survey", "home_type_survey",
+                  "max_price_survey", "desired_price_survey", "price_weight_survey", "air_conditioning_survey",
+                  "interior_washer_dryer_survey", "dish_washer_survey", "bath_survey", "parking_spot_survey",
+                  "building_washer_dryer_survey", "elevator_survey", "handicap_access_survey", "pool_hot_tub_survey",
+                  "fitness_center_survey", "storage_unit_survey", ]
 
 
 class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInformationForm,
@@ -308,7 +312,11 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, InteriorAmenitiesForm, PriceInfo
 
     class Meta:
         model = RentingSurveyModel
-        exclude = ["user_profile_survey", 'survey_type_survey', 'url']
+        fields = ["num_bedrooms_survey", "max_bathrooms_survey", "min_bathrooms_survey", "home_type_survey",
+                  "max_price_survey", "desired_price_survey", "price_weight_survey", "air_conditioning_survey",
+                  "interior_washer_dryer_survey", "dish_washer_survey", "bath_survey", "parking_spot_survey",
+                  "building_washer_dryer_survey", "elevator_survey", "handicap_access_survey", "pool_hot_tub_survey",
+                  "fitness_center_survey", "storage_unit_survey", "name_survey"]
 
 
 class CommuteInformationForm(ModelForm):

--- a/cocoon/survey/models.py
+++ b/cocoon/survey/models.py
@@ -33,7 +33,7 @@ class InitialSurveyModel(models.Model):
     survey_type_survey = models.IntegerField(default=-1)
     created_survey = models.DateField(auto_now_add=True)
     user_profile_survey = models.ForeignKey(UserProfile)
-    slug = models.SlugField(max_length=100)
+    url = models.SlugField(max_length=100)
 
     @property
     def name(self):
@@ -70,13 +70,13 @@ class InitialSurveyModel(models.Model):
     # Adds functionality to the save method. This checks to see if a survey with the same slug
     #   for that user already exists. If it does then delete that survey and save the new one instead
     def save(self, *args, **kwargs):
-        self.slug = self.generate_slug()
+        self.url = self.generate_slug()
 
         # Makes sure that the same slug doesn't exist for that user. If it does, then delete that survey
         if RentingSurveyModel.objects.filter(user_profile_survey=self.user_profile_survey)\
-                .filter(slug=self.slug).exists():
+                .filter(url=self.url).exists():
             RentingSurveyModel.objects.filter(user_profile_survey=self.user_profile)\
-                .filter(slug=self.slug).delete()
+                .filter(url=self.url).delete()
 
         # When the model is being saved, make sure to generate the slug associated with the survey.
         # Since surveys with duplicate names are deleted, then it should guarantee uniqueness

--- a/cocoon/survey/models.py
+++ b/cocoon/survey/models.py
@@ -32,6 +32,7 @@ class InitialSurveyModel(models.Model):
     survey_type_survey = models.IntegerField(default=-1)
     created_survey = models.DateField(auto_now_add=True)
     user_profile_survey = models.ForeignKey(UserProfile)
+    slug = models.SlugField(max_length=100)
 
     @property
     def name(self):
@@ -57,6 +58,14 @@ class InitialSurveyModel(models.Model):
     def user_profile(self, new_user_profile):
         self.user_profile_survey = new_user_profile
 
+    def generate_slug(self):
+        """
+        The slug should just be the name without spaces and with dashes instead.
+        This is because spaces look weird in urls and should be dashes instead
+        :return: (string) -> The generated slug
+        """
+        return self.name.replace(" ", "-")
+
     # Adds functionality to the save method. This checks to see if a survey with the same name
     #   for that user already exists. If it does then delete that survey and save the new one instead
     def save(self, *args, **kwargs):
@@ -64,6 +73,10 @@ class InitialSurveyModel(models.Model):
                 .filter(name_survey=self.name_survey).exists():
             RentingSurveyModel.objects.filter(user_profile_survey=self.user_profile)\
                 .filter(name_survey=self.name_survey).delete()
+
+        # When the model is being saved, make sure to generate the slug associated with the survey.
+        # Since surveys with duplicate names are deleted, then it should guarantee uniqueness
+        self.slug = self.generate_slug()
         super().save(*args, **kwargs)  # Call the "real" save() method.
 
     class Meta:

--- a/cocoon/survey/models.py
+++ b/cocoon/survey/models.py
@@ -57,6 +57,15 @@ class InitialSurveyModel(models.Model):
     def user_profile(self, new_user_profile):
         self.user_profile_survey = new_user_profile
 
+    # Adds functionality to the save method. This checks to see if a survey with the same name
+    #   for that user already exists. If it does then delete that survey and save the new one instead
+    def save(self, *args, **kwargs):
+        if RentingSurveyModel.objects.filter(user_profile_survey=self.user_profile_survey)\
+                .filter(name_survey=self.name_survey).exists():
+            RentingSurveyModel.objects.filter(user_profile_survey=self.user_profile)\
+                .filter(name_survey=self.name_survey).delete()
+        super().save(*args, **kwargs)  # Call the "real" save() method.
+
     class Meta:
         abstract = True
 

--- a/cocoon/survey/templates/survey/helpers/rent_mini_survey.html
+++ b/cocoon/survey/templates/survey/helpers/rent_mini_survey.html
@@ -13,7 +13,7 @@
 {% endcomment %}
 <div id="sidebarSurvey" class="sidenav">
     <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
-    <form action="{% url 'survey:rentSurveyResult' survey_slug=survey.slug %}" method="post">
+    <form action="{% url 'survey:rentSurveyResult' survey_url=survey.url %}" method="post">
         {{ form.non_field_errors }}
         {{ form.errors }}
         {% csrf_token %}

--- a/cocoon/survey/templates/survey/helpers/rent_mini_survey.html
+++ b/cocoon/survey/templates/survey/helpers/rent_mini_survey.html
@@ -13,7 +13,7 @@
 {% endcomment %}
 <div id="sidebarSurvey" class="sidenav">
     <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
-    <form action="{% url 'survey:rentSurveyResult' survey_id=survey.id %}" method="post">
+    <form action="{% url 'survey:rentSurveyResult' survey_slug=survey.slug %}" method="post">
         {{ form.non_field_errors }}
         {{ form.errors }}
         {% csrf_token %}

--- a/cocoon/survey/tests.py
+++ b/cocoon/survey/tests.py
@@ -983,3 +983,35 @@ class TestRentSurveModelMultipleNames(TestCase):
         self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
         self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey3.name_survey))
         self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey4.name_survey))
+
+    def testAddingHomeWithSameSlugDifferentName(self):
+        """
+        Tests that is the name are different but the slug names are the same. Then only one
+            will exist
+        """
+        # Arrange
+        # Create the first survey
+        survey1 = self.create_survey(self.user.userProfile, name="Recents")
+
+        survey2 = self.create_survey(self.user.userProfile, name="Recent's")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 1)
+        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey2.slug))
+
+    def testAddingHomeWithSameSlugDifferentNameDifferentUsers(self):
+        """
+        Tests that is the names are different but the slugs names are the same but they
+            are from different users, then they both will exist
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+        # Create the first survey
+        survey1 = self.create_survey(self.user.userProfile, name="Recents")
+
+        survey2 = self.create_survey(user2.userProfile, name="Recent's")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey1.slug))
+        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey2.slug))

--- a/cocoon/survey/tests.py
+++ b/cocoon/survey/tests.py
@@ -7,6 +7,8 @@ from cocoon.survey.forms import RentSurveyForm, HomeInformationForm, CommuteInfo
     InteriorAmenitiesForm, ExteriorAmenitiesForm
 from cocoon.houseDatabase.models import HomeTypeModel
 from cocoon.commutes.models import CommuteType
+from cocoon.survey.models import RentingSurveyModel
+from cocoon.userAuth.models import MyUser
 
 # Import cocoon global config values
 from config.settings.Global_Config import WEIGHT_QUESTION_MAX, MAX_NUM_BATHROOMS
@@ -841,3 +843,143 @@ class TestRentSurveyForm(TestCase):
 
         # Assert
         self.assertFalse(result)
+
+
+class TestRentSurveModelMultipleNames(TestCase):
+
+    def setUp(self):
+        # Create user for survey
+        self.user = MyUser.objects.create(email="test@email.com")
+
+    @staticmethod
+    def create_survey(user_profile, max_price=1500, desired_price=0, max_bathroom=2, min_bathroom=0,
+                      num_bedrooms=2, name="Recent Rent Survey"):
+        return RentingSurveyModel.objects.create(
+            name_survey=name,
+            user_profile_survey=user_profile,
+            max_price_survey=max_price,
+            desired_price_survey=desired_price,
+            max_bathrooms_survey=max_bathroom,
+            min_bathrooms_survey=min_bathroom,
+            num_bedrooms_survey=num_bedrooms,
+        )
+
+    def testAddingHomeWithOutOneExisting(self):
+        """
+        This test that if you add a home and there are no other surveys. The survey is
+            sucessfully created and exists in the database
+        """
+        # Arrange
+        survey = self.create_survey(self.user.userProfile)
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 1)
+        self.assertEqual(RentingSurveyModel.objects.first(), survey)
+
+    def testAddingHomeWithOneExistingDifferentNames(self):
+        """
+        This tests that if you add two surveys with different names then both will be added
+            and exist
+        """
+        # Arrange
+        # Create the first survey
+        survey1 = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+
+        survey2 = self.create_survey(self.user.userProfile, name="Test 2")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey1.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+
+    def testAddingHomeWithOneExistingSameName(self):
+        """
+        This tests that if you add two surveys with the same name, the first survey will
+            be overwritten and deleted before saving the second survey
+        """
+        # Arrange
+        # Create the first survey
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 1)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+
+    def testAddingHomeWithTwoExistingSameNamePlusOthers(self):
+        """
+        This tests that if you add mutiple with the same name, only the last one will persist.
+            Also checks to make sure other surveys are not effected
+        """
+        # Arrange
+        # Create the first survey
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey1 = self.create_survey(self.user.userProfile, name="Some Random Name")
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey1.name_survey))
+
+    def testAddingHomeWithOneExistingSameNameDifferentUsers(self):
+        """
+        Test that surveys from other users are not effected. If two surveys from different users
+            have the same name, then it should not touch them, aka delete them
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+
+        # Create the first survey
+        survey = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(user2.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+
+    def testAddingHomeWithOneExistingSameNameMultipleUsers(self):
+        """
+        Tests that even with 3 users, the condition still holds
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+        user3 = MyUser.objects.create(email="test3@test.com")
+
+        # Create the first survey
+        survey = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(user2.userProfile, name="Recent Rent Survey")
+        survey3 = self.create_survey(user3.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 3)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey3.name_survey))
+
+    def testAddingHomeWithOneExistingSameNameMultipleUsersAllHaveMultiple(self):
+        """
+        Tests a complex scenario where two users have duplicates and one doesn't. Makes sure
+            the functionality works
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+        user3 = MyUser.objects.create(email="test3@test.com")
+
+        # Create the first survey
+        survey = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(user2.userProfile, name="Recent Rent Survey")
+        survey3 = self.create_survey(user3.userProfile, name="Recent Rent Survey")
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        self.create_survey(user2.userProfile, name="Recent Rent Survey")
+        survey4 = self.create_survey(user3.userProfile, name="Test Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 4)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey3.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey4.name_survey))

--- a/cocoon/survey/tests/tests_models.py
+++ b/cocoon/survey/tests/tests_models.py
@@ -158,7 +158,7 @@ class TestRentSurveyModelMultipleNames(TestCase):
 
         # Assert
         self.assertEqual(RentingSurveyModel.objects.count(), 1)
-        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey2.slug))
+        self.assertTrue(RentingSurveyModel.objects.filter(url=survey2.url))
 
     def testAddingHomeWithSameSlugDifferentNameDifferentUsers(self):
         """
@@ -174,5 +174,5 @@ class TestRentSurveyModelMultipleNames(TestCase):
 
         # Assert
         self.assertEqual(RentingSurveyModel.objects.count(), 2)
-        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey1.slug))
-        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey2.slug))
+        self.assertTrue(RentingSurveyModel.objects.filter(url=survey1.url))
+        self.assertTrue(RentingSurveyModel.objects.filter(url=survey2.url))

--- a/cocoon/survey/tests/tests_models.py
+++ b/cocoon/survey/tests/tests_models.py
@@ -1,0 +1,178 @@
+# Import Django Modules
+from django.test import TestCase
+
+# Import Survey Models and forms
+from cocoon.survey.models import RentingSurveyModel
+from cocoon.userAuth.models import MyUser
+
+
+class TestRentSurveyModelMultipleNames(TestCase):
+
+    def setUp(self):
+        # Create user for survey
+        self.user = MyUser.objects.create(email="test@email.com")
+
+    @staticmethod
+    def create_survey(user_profile, max_price=1500, desired_price=0, max_bathroom=2, min_bathroom=0,
+                      num_bedrooms=2, name="Recent Rent Survey"):
+        return RentingSurveyModel.objects.create(
+            name_survey=name,
+            user_profile_survey=user_profile,
+            max_price_survey=max_price,
+            desired_price_survey=desired_price,
+            max_bathrooms_survey=max_bathroom,
+            min_bathrooms_survey=min_bathroom,
+            num_bedrooms_survey=num_bedrooms,
+        )
+
+    def testAddingHomeWithOutOneExisting(self):
+        """
+        This test that if you add a home and there are no other surveys. The survey is
+            sucessfully created and exists in the database
+        """
+        # Arrange
+        survey = self.create_survey(self.user.userProfile)
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 1)
+        self.assertEqual(RentingSurveyModel.objects.first(), survey)
+
+    def testAddingHomeWithOneExistingDifferentNames(self):
+        """
+        This test2 that if you add two surveys with different names then both will be added
+            and exist
+        """
+        # Arrange
+        # Create the first survey
+        survey1 = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+
+        survey2 = self.create_survey(self.user.userProfile, name="Test 2")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey1.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+
+    def testAddingHomeWithOneExistingSameName(self):
+        """
+        This test2 that if you add two surveys with the same name, the first survey will
+            be overwritten and deleted before saving the second survey
+        """
+        # Arrange
+        # Create the first survey
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 1)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+
+    def testAddingHomeWithTwoExistingSameNamePlusOthers(self):
+        """
+        This test2 that if you add mutiple with the same name, only the last one will persist.
+            Also checks to make sure other surveys are not effected
+        """
+        # Arrange
+        # Create the first survey
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey1 = self.create_survey(self.user.userProfile, name="Some Random Name")
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey1.name_survey))
+
+    def testAddingHomeWithOneExistingSameNameDifferentUsers(self):
+        """
+        Test that surveys from other users are not effected. If two surveys from different users
+            have the same name, then it should not touch them, aka delete them
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+
+        # Create the first survey
+        survey = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(user2.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+
+    def testAddingHomeWithOneExistingSameNameMultipleUsers(self):
+        """
+        Tests that even with 3 users, the condition still holds
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+        user3 = MyUser.objects.create(email="test3@test.com")
+
+        # Create the first survey
+        survey = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(user2.userProfile, name="Recent Rent Survey")
+        survey3 = self.create_survey(user3.userProfile, name="Recent Rent Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 3)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey3.name_survey))
+
+    def testAddingHomeWithOneExistingSameNameMultipleUsersAllHaveMultiple(self):
+        """
+        Tests a complex scenario where two users have duplicates and one doesn't. Makes sure
+            the functionality works
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+        user3 = MyUser.objects.create(email="test3@test.com")
+
+        # Create the first survey
+        survey = self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        survey2 = self.create_survey(user2.userProfile, name="Recent Rent Survey")
+        survey3 = self.create_survey(user3.userProfile, name="Recent Rent Survey")
+        self.create_survey(self.user.userProfile, name="Recent Rent Survey")
+        self.create_survey(user2.userProfile, name="Recent Rent Survey")
+        survey4 = self.create_survey(user3.userProfile, name="Test Survey")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 4)
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey2.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey3.name_survey))
+        self.assertTrue(RentingSurveyModel.objects.filter(name_survey=survey4.name_survey))
+
+    def testAddingHomeWithSameSlugDifferentName(self):
+        """
+        Tests that is the name are different but the slug names are the same. Then only one
+            will exist
+        """
+        # Arrange
+        # Create the first survey
+        survey1 = self.create_survey(self.user.userProfile, name="Recents")
+
+        survey2 = self.create_survey(self.user.userProfile, name="Recent's")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 1)
+        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey2.slug))
+
+    def testAddingHomeWithSameSlugDifferentNameDifferentUsers(self):
+        """
+        Tests that is the names are different but the slugs names are the same but they
+            are from different users, then they both will exist
+        """
+        # Arrange
+        user2 = MyUser.objects.create(email="test2@test.com")
+        # Create the first survey
+        survey1 = self.create_survey(self.user.userProfile, name="Recents")
+
+        survey2 = self.create_survey(user2.userProfile, name="Recent's")
+
+        # Assert
+        self.assertEqual(RentingSurveyModel.objects.count(), 2)
+        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey1.slug))
+        self.assertTrue(RentingSurveyModel.objects.filter(slug=survey2.slug))

--- a/cocoon/survey/urls.py
+++ b/cocoon/survey/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     # url(r'^buy/$', views.buying_survey, name="buyingSurvey"),
     url(r'^visits/$', views.visit_list, name="visitList"),
     url(r'^result/rent/$', views.survey_result_rent, name="rentSurveyResult"),
-    url(r'^result/rent/(?P<survey_id>[0-9]+)/$', views.survey_result_rent, name="rentSurveyResult"),
+    url(r'^result/rent/(?P<survey_slug>.*)/$', views.survey_result_rent, name="rentSurveyResult"),
     # Ajax requests
     url(r'^setFavorite/$', views.set_favorite, name="setFavorite"),
     url(r'^deleteSurvey/$', views.delete_survey, name="surveyDelete"),

--- a/cocoon/survey/urls.py
+++ b/cocoon/survey/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     # url(r'^buy/$', views.buying_survey, name="buyingSurvey"),
     url(r'^visits/$', views.visit_list, name="visitList"),
     url(r'^result/rent/$', views.survey_result_rent, name="rentSurveyResult"),
-    url(r'^result/rent/(?P<survey_slug>.*)/$', views.survey_result_rent, name="rentSurveyResult"),
+    url(r'^result/rent/(?P<survey_url>.*)/$', views.survey_result_rent, name="rentSurveyResult"),
     # Ajax requests
     url(r'^setFavorite/$', views.set_favorite, name="setFavorite"),
     url(r'^deleteSurvey/$', views.delete_survey, name="surveyDelete"),

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -163,7 +163,7 @@ def run_rent_algorithm(survey, context):
 # Assumes the survey_slug will be passed by the URL if not, then it grabs the most recent survey.
 # If it can't find the most recent survey it redirects back to the survey
 @login_required
-def survey_result_rent(request, survey_slug="recent"):
+def survey_result_rent(request, survey_slug=""):
     """
     Survey result rent is the heart of the website where the survey is grabbed and the housing list is created
     Based on the results of the survey. This is specifically for the rent survey
@@ -181,36 +181,21 @@ def survey_result_rent(request, survey_slug="recent"):
     }
 
     user_profile = get_object_or_404(UserProfile, user=request.user)
-    # If no id is specified in the URL, then it attempts to load the recent survey
-    # The recent survey is the last survey to be created
-    if survey_slug == "recent":
-        # Try to retrieve the most recent survey, but if there are no surveys, then
-        # Redirect back to the homepage
+
+    # Tries to grab the survey. If the survey name was not passed in, then it grabs the most recent survey taken.
+    try:
+        survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile).get(slug=survey_slug)
+    # If the survey ID, does not exist/is not for that user, then return the most recent survey
+    except RentingSurveyModel.DoesNotExist:
         if RentingSurveyModel.objects.filter(user_profile_survey=user_profile).exists():
-            survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile) \
+            survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile)\
                 .order_by('created_survey').first()
+            messages.add_message(request, messages.WARNING, 'Could not find Survey, loading most recent survey')
             return HttpResponseRedirect(reverse('survey:rentSurveyResult',
                                                 kwargs={"survey_slug": survey.slug}))
         else:
-            messages.add_message(request, messages.ERROR, 'Could not find any surveys. Please take one!')
+            messages.add_message(request, messages.ERROR, 'Could not find Survey')
             return HttpResponseRedirect(reverse('homePage:index'))
-    else:
-        # If the user did not choose recent, then try to grab the survey by it's id
-        # If it can't find it or it is not associated with the user, just grab the
-        # Recent Survey. If that fails, then redirect back to the home page.
-        try:
-            survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile).get(slug=survey_slug)
-        # If the survey ID, does not exist/is not for that user, then return the most recent survey
-        except RentingSurveyModel.DoesNotExist:
-            if RentingSurveyModel.objects.filter(user_profile_survey=user_profile).exists():
-                survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile)\
-                    .order_by('created_survey').first()
-                messages.add_message(request, messages.WARNING, 'Could not find Survey, loading most recent survey')
-                return HttpResponseRedirect(reverse('survey:rentSurveyResult',
-                                                    kwargs={"survey_slug": survey.slug}))
-            else:
-                messages.add_message(request, messages.ERROR, 'Could not find Survey')
-                return HttpResponseRedirect(reverse('homePage:index'))
 
     # Populate form with stored data
     form = RentSurveyFormMini(instance=survey)

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -83,7 +83,7 @@ def renting_survey(request):
 
                 # redirect to survey result on success:
                 return HttpResponseRedirect(reverse('survey:rentSurveyResult',
-                                                    kwargs={"survey_url": rent_survey.survey_url}))
+                                                    kwargs={"survey_url": rent_survey.url}))
 
             else:
                 context['error_message'] = "The destination set did not validate"

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -83,7 +83,7 @@ def renting_survey(request):
 
                 # redirect to survey result on success:
                 return HttpResponseRedirect(reverse('survey:rentSurveyResult',
-                                                    kwargs={"survey_slug": rent_survey.slug}))
+                                                    kwargs={"survey_url": rent_survey.survey_url}))
 
             else:
                 context['error_message'] = "The destination set did not validate"
@@ -163,12 +163,12 @@ def run_rent_algorithm(survey, context):
 # Assumes the survey_slug will be passed by the URL if not, then it grabs the most recent survey.
 # If it can't find the most recent survey it redirects back to the survey
 @login_required
-def survey_result_rent(request, survey_slug=""):
+def survey_result_rent(request, survey_url=""):
     """
     Survey result rent is the heart of the website where the survey is grabbed and the housing list is created
     Based on the results of the survey. This is specifically for the rent survey
     :param request: (Http Request): The HTTP request object
-    :param survey_slug: (string): This is the survey slug to determine which survey to load
+    :param survey_url: (string): This is the survey slug to determine which survey to load
     :return: HttpResponse if everything goes well. It returns a lot of context variables like the housingList
         etc. If something goes wrong then it may redirect back to the survey homePage
 
@@ -184,7 +184,7 @@ def survey_result_rent(request, survey_slug=""):
 
     # Tries to grab the survey. If the survey name was not passed in, then it grabs the most recent survey taken.
     try:
-        survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile).get(slug=survey_slug)
+        survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile).get(url=survey_url)
     # If the survey ID, does not exist/is not for that user, then return the most recent survey
     except RentingSurveyModel.DoesNotExist:
         if RentingSurveyModel.objects.filter(user_profile_survey=user_profile).exists():
@@ -192,7 +192,7 @@ def survey_result_rent(request, survey_slug=""):
                 .order_by('created_survey').first()
             messages.add_message(request, messages.WARNING, 'Could not find Survey, loading most recent survey')
             return HttpResponseRedirect(reverse('survey:rentSurveyResult',
-                                                kwargs={"survey_slug": survey.slug}))
+                                                kwargs={"survey_url": survey.url}))
         else:
             messages.add_message(request, messages.ERROR, 'Could not find Survey')
             return HttpResponseRedirect(reverse('homePage:index'))
@@ -218,7 +218,7 @@ def survey_result_rent(request, survey_slug=""):
                 form.save()
                 destination_form_set.save()
                 return HttpResponseRedirect(reverse('survey:rentSurveyResult',
-                                                    kwargs={"survey_slug": survey.slug}))
+                                                    kwargs={"survey_url": survey.url}))
             else:
                 context['error_message'].append("There are form errors in destinatino form")
                 context['error_message'].append(destination_form_set.errors)

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -76,12 +76,6 @@ def renting_survey(request):
 
             if destination_form_set.is_valid():
 
-                # Try seeing if there is already a recent survey and if there is
-                # Then delete it. We only want to keep one "recent" survey
-                # The user has the option to change the name of it to save it permanently
-                RentingSurveyModel.objects.filter(user_profile_survey=current_profile).filter(
-                    name_survey=DEFAULT_RENT_SURVEY_NAME).delete()
-
                 # Only if all the forms validate will we save it to the database
                 rent_survey.save()
                 form.save_m2m()

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -226,7 +226,7 @@ def survey_result_rent(request, survey_id="recent"):
     if request.method == 'POST':
         # If a POST occurs, update the form. In the case of an error, then the survey
         # Should be populated by the POST data.
-        form = RentSurveyFormMini(request.POST, instance=survey)
+        form = RentSurveyFormMini(request.POST, instance=survey, user=request.user)
         destination_form_set = DestinationFormSet(request.POST, instance=survey)
         # If the survey is valid then redirect back to the page to reload the changes
         # This will also update the house list

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from django.forms import inlineformset_factory
 
 # Import Global config variables
-from config.settings.Global_Config import survey_types, DEFAULT_RENT_SURVEY_NAME
+from config.settings.Global_Config import survey_types
 
 # Import House Database modules
 from cocoon.houseDatabase.models import RentDatabaseModel

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -83,7 +83,7 @@ def renting_survey(request):
 
                 # redirect to survey result on success:
                 return HttpResponseRedirect(reverse('survey:rentSurveyResult',
-                                                    kwargs={"survey_id": rent_survey.id}))
+                                                    kwargs={"survey_slug": rent_survey.slug}))
 
             else:
                 context['error_message'] = "The destination set did not validate"
@@ -160,16 +160,15 @@ def run_rent_algorithm(survey, context):
     context['houseList'] = rent_algorithm.homes[:50]
 
 
-# Assumes the survey_id will be passed by the URL if not, then it grabs the most recent survey.
+# Assumes the survey_slug will be passed by the URL if not, then it grabs the most recent survey.
 # If it can't find the most recent survey it redirects back to the survey
 @login_required
-def survey_result_rent(request, survey_id="recent"):
+def survey_result_rent(request, survey_slug="recent"):
     """
     Survey result rent is the heart of the website where the survey is grabbed and the housing list is created
     Based on the results of the survey. This is specifically for the rent survey
     :param request: (Http Request): The HTTP request object
-    :param survey_id: (string): This is the survey id that corresponds to the survey that is desired
-        If no id is specified then the latest survey is used
+    :param survey_slug: (string): This is the survey slug to determine which survey to load
     :return: HttpResponse if everything goes well. It returns a lot of context variables like the housingList
         etc. If something goes wrong then it may redirect back to the survey homePage
 
@@ -184,27 +183,32 @@ def survey_result_rent(request, survey_id="recent"):
     user_profile = get_object_or_404(UserProfile, user=request.user)
     # If no id is specified in the URL, then it attempts to load the recent survey
     # The recent survey is the last survey to be created
-    if survey_id == "recent":
+    if survey_slug == "recent":
         # Try to retrieve the most recent survey, but if there are no surveys, then
         # Redirect back to the homepage
-        try:
-            survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile).order_by('-created').first()
-        except RentingSurveyModel.DoesNotExist:
-            messages.add_message(request, messages.ERROR, 'Could not find Survey')
+        if RentingSurveyModel.objects.filter(user_profile_survey=user_profile).exists():
+            survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile) \
+                .order_by('created_survey').first()
+            return HttpResponseRedirect(reverse('survey:rentSurveyResult',
+                                                kwargs={"survey_slug": survey.slug}))
+        else:
+            messages.add_message(request, messages.ERROR, 'Could not find any surveys. Please take one!')
             return HttpResponseRedirect(reverse('homePage:index'))
     else:
         # If the user did not choose recent, then try to grab the survey by it's id
         # If it can't find it or it is not associated with the user, just grab the
         # Recent Survey. If that fails, then redirect back to the home page.
         try:
-            survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile).get(id=survey_id)
+            survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile).get(slug=survey_slug)
         # If the survey ID, does not exist/is not for that user, then return the most recent survey
         except RentingSurveyModel.DoesNotExist:
-            context['error_message'].append("Could not find survey id, getting recent survey")
-            try:
+            if RentingSurveyModel.objects.filter(user_profile_survey=user_profile).exists():
                 survey = RentingSurveyModel.objects.filter(user_profile_survey=user_profile)\
-                    .order_by('-created').first()
-            except RentingSurveyModel.DoesNotExist:
+                    .order_by('created_survey').first()
+                messages.add_message(request, messages.WARNING, 'Could not find Survey, loading most recent survey')
+                return HttpResponseRedirect(reverse('survey:rentSurveyResult',
+                                                    kwargs={"survey_slug": survey.slug}))
+            else:
                 messages.add_message(request, messages.ERROR, 'Could not find Survey')
                 return HttpResponseRedirect(reverse('homePage:index'))
 
@@ -229,7 +233,7 @@ def survey_result_rent(request, survey_id="recent"):
                 form.save()
                 destination_form_set.save()
                 return HttpResponseRedirect(reverse('survey:rentSurveyResult',
-                                                    kwargs={"survey_id": survey.id}))
+                                                    kwargs={"survey_slug": survey.slug}))
             else:
                 context['error_message'].append("There are form errors in destinatino form")
                 context['error_message'].append(destination_form_set.errors)

--- a/cocoon/userAuth/templates/userAuth/user_surveys.html
+++ b/cocoon/userAuth/templates/userAuth/user_surveys.html
@@ -133,7 +133,7 @@
                                                 {% endwith %}
                                                 </tbody>
                                             </table>
-                                            <a href="{% url 'survey:rentSurveyResult' survey_slug=survey.slug %}"
+                                            <a href="{% url 'survey:rentSurveyResult' survey_url=survey.url %}"
                                                class="btn btn-primary active" role="button">Load!</a>
                                         </div>
                                     </div>

--- a/cocoon/userAuth/templates/userAuth/user_surveys.html
+++ b/cocoon/userAuth/templates/userAuth/user_surveys.html
@@ -133,7 +133,7 @@
                                                 {% endwith %}
                                                 </tbody>
                                             </table>
-                                            <a href="{% url 'survey:rentSurveyResult' survey_id=survey.id %}"
+                                            <a href="{% url 'survey:rentSurveyResult' survey_slug=survey.slug %}"
                                                class="btn btn-primary active" role="button">Load!</a>
                                         </div>
                                     </div>

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -202,46 +202,60 @@ LOGGING = {
         'cocoon.userAuth': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
 
         # Survey app loggers
         'cocoon.survey': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
         'cocoon.survey.cocoon_algorithm': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
         'cocoon.survey.distance_matrix': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
         'cocoon.survey.home_data': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
         'cocoon.survey.view': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
+        },
+        'cocoon.survey.models': {
+            'handlers': ['console', 'mail_admins', 'file'],
+            'level': 'DEBUG',
+            'propagate': False,
         },
 
         # Commute app logger
         'cocoon.commutes': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
 
         # HomePage app logger
         'cocoon.homePage': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
 
         # HouseDatabase app logger
         'cocoon.houseDatabase': {
             'handlers': ['console', 'mail_admins', 'file'],
             'level': 'DEBUG',
+            'propagate': False,
         },
     },
 }


### PR DESCRIPTION
This adds the functionality where the survey is loaded via the survey name (actually slug) instead of the survey id. This prevents security bugs of giving away sequential data from the database and also makes the url neater