### PR TITLE
[issue-155] Limit max zoom.

### DIFF
--- a/cocoon/survey/static/survey/addGoogleMap.js
+++ b/cocoon/survey/static/survey/addGoogleMap.js
@@ -5,7 +5,7 @@
 var map;
 var markers = [];
 var MAPZOOM = 12;
-var MAXZOOM = 16;
+var MAXZOOM = 13;
 
 /**
  * function required by google maps api for initialization


### PR DESCRIPTION
Limits the max zoom. It is a frontend change so they could go into javascript and change it and zoom in more, but I feel like we don't need to worry about people doing that. Also it still doesn't give them the address if they try to hack us to zoom in more