### PR TITLE
Issue 181 best transit mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .idea/
 
 # Ignore the settings file
-config/settings/secrets.json
+config/settings/secret.json
 
 # Ignore the other apache files that isn't the template file
 config/apache2/*.conf

--- a/cocoon/commutes/admin.py
+++ b/cocoon/commutes/admin.py
@@ -35,7 +35,6 @@ class TransitTypeAdmin(admin.ModelAdmin):
     ]
     list_display = ('transit_type',)
 
-
 admin.site.register(ZipCodeBase, ZipCodeAdmin)
 admin.site.register(CommuteType, CommuteTypeAdmin)
 admin.site.register(TransitType, TransitTypeAdmin)

--- a/cocoon/commutes/admin.py
+++ b/cocoon/commutes/admin.py
@@ -2,7 +2,7 @@
 from django.contrib import admin
 
 # Commute imports
-from .models import ZipCodeBase, ZipCodeChild, CommuteType
+from .models import ZipCodeBase, ZipCodeChild, CommuteType, TransitType
 
 
 class ZipCodeChildInLine(admin.StackedInline):
@@ -28,6 +28,14 @@ class CommuteTypeAdmin(admin.ModelAdmin):
     ]
     list_display = ('commute_type',)
 
+class TransitTypeAdmin(admin.ModelAdmin):
+    fieldsets = [
+        ('Transit Type',
+         {'fields': ['transit_type', ]})
+    ]
+    list_display = ('transit_type',)
+
 
 admin.site.register(ZipCodeBase, ZipCodeAdmin)
 admin.site.register(CommuteType, CommuteTypeAdmin)
+admin.site.register(TransitType, TransitTypeAdmin)

--- a/cocoon/commutes/distance_matrix/distance_wrapper.py
+++ b/cocoon/commutes/distance_matrix/distance_wrapper.py
@@ -87,7 +87,7 @@ class DistanceWrapper:
         # list of lists of durations from origin to destinations
         return distance_list
 
-    def get_durations_and_distances(self, origins, destinations, transit_option, mode="driving"):
+    def get_durations_and_distances(self, origins, destinations, transit_option=[], mode="driving"):
         """
         Gets the distance matrix corresponding to a destination and an arbitrary number of origins.
         Segments requests to the distance matrix API to include a maximum of 25 origins and returns

--- a/cocoon/commutes/distance_matrix/distance_wrapper.py
+++ b/cocoon/commutes/distance_matrix/distance_wrapper.py
@@ -113,6 +113,10 @@ class DistanceWrapper:
         # maximizes 100 elements while retaining 25 origin/dest limit
         destination_number = min(25, len(destinations))
         origin_number = min((100 / destination_number), 25)
+        transit_option = ""
+        if(mode == "Bus" or mode == "Subway" or mode == "Train"):
+            transit_option = mode
+            mode = 'transit'
 
         while origin_list:
             # only computes for the first destination_number destinations
@@ -121,7 +125,8 @@ class DistanceWrapper:
                                                             destinations[:destination_number],
                                                             units=self.units,
                                                             # make sure the mode is lower case
-                                                            mode=mode.lower())
+                                                            mode=mode.lower(),
+                                                            transit_mode=transit_option)
             response_list = self.interpret_distance_matrix_response(response_json)
             # each inner list the entire results of an origin
             for res in response_list:

--- a/cocoon/commutes/distance_matrix/distance_wrapper.py
+++ b/cocoon/commutes/distance_matrix/distance_wrapper.py
@@ -113,9 +113,9 @@ class DistanceWrapper:
         # maximizes 100 elements while retaining 25 origin/dest limit
         destination_number = min(25, len(destinations))
         origin_number = min((100 / destination_number), 25)
-        transit_option = ""
+        transit_option = []
         if(mode == "Bus" or mode == "Subway" or mode == "Train"):
-            transit_option = mode
+            transit_option.append(mode.lower())
             mode = 'transit'
 
         while origin_list:

--- a/cocoon/commutes/distance_matrix/distance_wrapper.py
+++ b/cocoon/commutes/distance_matrix/distance_wrapper.py
@@ -64,7 +64,7 @@ class DistanceWrapper:
         response_status = response_obj["status"]
         distance_list = []
         if response_status == "OK":
-
+            print(response_obj)
             # each row is an origin
             for row in response_obj["rows"]:
                 origin_distance_list = []
@@ -87,7 +87,7 @@ class DistanceWrapper:
         # list of lists of durations from origin to destinations
         return distance_list
 
-    def get_durations_and_distances(self, origins, destinations, mode="driving"):
+    def get_durations_and_distances(self, origins, destinations, transit_option, mode="driving"):
         """
         Gets the distance matrix corresponding to a destination and an arbitrary number of origins.
         Segments requests to the distance matrix API to include a maximum of 25 origins and returns
@@ -113,10 +113,6 @@ class DistanceWrapper:
         # maximizes 100 elements while retaining 25 origin/dest limit
         destination_number = min(25, len(destinations))
         origin_number = min((100 / destination_number), 25)
-        transit_option = []
-        if(mode == "Bus" or mode == "Subway" or mode == "Train"):
-            transit_option.append(mode.lower())
-            mode = 'transit'
 
         while origin_list:
             # only computes for the first destination_number destinations

--- a/cocoon/commutes/models.py
+++ b/cocoon/commutes/models.py
@@ -30,6 +30,7 @@ class CommuteType(models.Model):
 
 
 class TransitType(models.Model):
+
     TRANSIT_TYPES = (
         ('Bus', 'Bus'),
         ('Subway', 'Subway'),

--- a/cocoon/commutes/models.py
+++ b/cocoon/commutes/models.py
@@ -15,14 +15,10 @@ class CommuteType(models.Model):
 
     COMMUTE_TYPES = (
         ('Driving', 'Driving'),
-        ('Bus', 'Bus'),
-        ('Rail', 'Rail'),
-        ('Subway', 'Subway'),
-        ('Train', 'Train'),
-        ('Tram', 'Tram'),
         ('Walking', 'Walking'),
         ('Bicycling', 'Bicycling'),
     )
+
     commute_type = models.CharField(
         unique=True,
         choices=COMMUTE_TYPES,
@@ -31,6 +27,23 @@ class CommuteType(models.Model):
 
     def __str__(self):
         return self.commute_type
+
+
+class TransitType(models.Model):
+    TRANSIT_TYPES = (
+        ('Bus', 'Bus'),
+        ('Subway', 'Subway'),
+        ('Train', 'Train')
+    )
+
+    transit_type = models.CharField(
+        unique=True,
+        choices=TRANSIT_TYPES,
+        max_length=200,
+    )
+
+    def __str__(self):
+        return self.transit_type
 
 
 class ZipCodeBase(models.Model):

--- a/cocoon/commutes/models.py
+++ b/cocoon/commutes/models.py
@@ -15,7 +15,11 @@ class CommuteType(models.Model):
 
     COMMUTE_TYPES = (
         ('Driving', 'Driving'),
-        ('Transit', 'Transit'),
+        ('Bus', 'Bus'),
+        ('Rail', 'Rail'),
+        ('Subway', 'Subway'),
+        ('Train', 'Train'),
+        ('Tram', 'Tram'),
         ('Walking', 'Walking'),
         ('Bicycling', 'Bicycling'),
     )

--- a/cocoon/homePage/static/homePage/landingPage.css
+++ b/cocoon/homePage/static/homePage/landingPage.css
@@ -38,10 +38,6 @@ body {
     font-size: 16px;
 }
 
-.jumbotron > p.lead:after {
-    content: "Here at Cocoon, we strive to find you the perfect home!";
-}
-
 .landingImage {
     width: 100%;
 }

--- a/cocoon/homePage/templates/homePage/index.html
+++ b/cocoon/homePage/templates/homePage/index.html
@@ -72,7 +72,7 @@
 
     <div class="info-row">
         {% if is_broker %}
-            <div class="info-text"><span>Find an apartment for your client <span class="inline-emphasis">apartment</span> on Cocoon!</span>
+            <div class="info-text"><span>Start and end your search for your clients <span class="inline-emphasis">apartment</span> on Cocoon!</span>
             </div>
         {% else %}
             <div class="info-text"><span>Start and end your search for an <span class="inline-emphasis">apartment</span> on Cocoon!</span>

--- a/cocoon/homePage/templates/homePage/index.html
+++ b/cocoon/homePage/templates/homePage/index.html
@@ -3,94 +3,114 @@
 {% block title %}Cocoon{% endblock %}
 
 {% block head %}
-  {{ block.super }}
-  {% comment %} Domain Verfication{% endcomment %}
-  <meta name="google-site-verification" content="EZpbJ3VrkWORskv6xVg5hoxs3cjmN7UBjbKu6AZW4C8"/>
-  <!-- JQuery UI style sheet, mostly used for slider ui -->
-  <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-  <!-- Style sheets for template page -->
-  <link href="{% static 'survey/css/dashboard.css' %}" rel="stylesheet">
-  <link href="{% static 'homePage/landingPage.css' %}" rel="stylesheet">
+    {{ block.super }}
+    {% comment %} Domain Verfication{% endcomment %}
+    <meta name="google-site-verification" content="EZpbJ3VrkWORskv6xVg5hoxs3cjmN7UBjbKu6AZW4C8"/>
+    <!-- JQuery UI style sheet, mostly used for slider ui -->
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <!-- Style sheets for template page -->
+    <link href="{% static 'survey/css/dashboard.css' %}" rel="stylesheet">
+    <link href="{% static 'homePage/landingPage.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
 
-  <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
+    <div id="carousel-example-generic" class="carousel slide" data-ride="carousel">
 
-    <!-- Indicators, which go here, were removed. -->
+        <!-- Indicators, which go here, were removed. -->
 
-    <div class="jumbotron">
-      {% if  user.is_authenticated %}
-        <h1>Hey {{ user.first_name }}</h1>
-      {% else %}
-        <h1>Welcome to Cocoon!</h1>
-      {% endif %}
-      <p class="lead"></p>
-      {% if not user.is_authenticated %}
-        <p>Please sign in:
-          <a href="{% url "userAuth:loginPage" %}">
-            <button class="login-button btn btn-primary">Login</button>
-          </a>
-        </p>
-      {% else %}
-        <p>Please click below to get started!</p>
-      {% endif %}
+        <div class="jumbotron">
+            {% if  user.is_authenticated %}
+                <h1>Hey {{ user.first_name }}</h1>
+            {% else %}
+                <h1>Welcome to Cocoon!</h1>
+            {% endif %}
+            <p class="lead"></p>
+            {% if not user.is_authenticated %}
+                <p>Please sign in:
+                    <a href="{% url "userAuth:loginPage" %}">
+                        <button class="login-button btn btn-primary">Login</button>
+                    </a>
+                </p>
+            {% else %}
+                {% if is_broker %}
+                    <p>Here at Cocoon, we strive to find your clients a perfect home!</p>
+                {% else %}
+                    <p>Here at Cocoon, we strive to find you perfect home!</p>
+                {% endif %}
+                <p>Please click below to get started!</p>
+            {% endif %}
+        </div>
+
+        <img class="landingImage" src="{% static 'stockHomes/landing_image.jpeg' %}" alt>
+
     </div>
 
-    <img class="landingImage" src="{% static 'stockHomes/landing_image.jpeg' %}" alt>
+    {% if messages %}
+        <ul class="messages">
+            {% for message in messages %}
+                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+    {% if error_message %}
+        <div class="row">
+            <div class="col-sm-offset-3 col-sm-6" style="color:red">
+                <p><strong>{{ error_message }}</strong></p>
+            </div>
+        </div>
+    {% endif %}
 
-  </div>
-
-  {% if messages %}
-    <ul class="messages">
-      {% for message in messages %}
-        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-  {% if error_message %}
-    <div class="row">
-      <div class="col-sm-offset-3 col-sm-6" style="color:red">
-        <p><strong>{{ error_message }}</strong></p>
-      </div>
+    <div class="selectSurvey">
+        <h2>Take a survey now</h2>
+        <div class="surveyButton">
+            <p><a href="{% url 'survey:rentingSurvey' %}">
+                <button class="submitButton btn-lg btn-primary">Start</button>
+            </a></p>
+        </div>
     </div>
-  {% endif %}
 
-  <div class="selectSurvey">
-    <h2>Take a survey now</h2>
-    <div class="surveyButton">
-      <p><a href="{% url 'survey:rentingSurvey' %}">
-        <button class="submitButton btn-lg btn-primary">Start</button>
-      </a></p>
+    <div class="info-row">
+        {% if is_broker %}
+            <div class="info-text"><span>Find an apartment for your client <span class="inline-emphasis">apartment</span> on Cocoon!</span>
+            </div>
+        {% else %}
+            <div class="info-text"><span>Start and end your search for an <span class="inline-emphasis">apartment</span> on Cocoon!</span>
+            </div>
+        {% endif %}
+        <div class="icon-container">
+            <img class="infographic" src="{% static 'infographics/vector_apartment.svg' %}">
+        </div>
     </div>
-  </div>
 
-  <div class="info-row">
-    <div class="info-text"><span>Start and end your search for an <span class="inline-emphasis">apartment</span> on Cocoon!</span>
+    <div class="info-row">
+        {% if is_broker %}
+            <div class="info-text"><span>Complete our <span
+                    class="inline-emphasis">survey</span> detailing your clients every need!</span></div>
+        {% else %}
+            <div class="info-text"><span>Complete our <span
+                    class="inline-emphasis">survey</span> detailing your every need!</span></div>
+        {% endif %}
+        <div class="icon-container">
+            <img class="infographic" src="{% static 'infographics/vector_survey.svg' %}">
+        </div>
     </div>
-    <div class="icon-container">
-      <img class="infographic" src="{% static 'infographics/vector_apartment.svg' %}">
-    </div>
-  </div>
 
-  <div class="info-row">
-    <div class="info-text"><span>Complete our <span
-        class="inline-emphasis">survey</span> detailing your every need!</span></div>
-    <div class="icon-container">
-      <img class="infographic" src="{% static 'infographics/vector_survey.svg' %}">
+    <div class="info-row">
+        {% if is_broker %}
+            <div class="info-text"><span>Let us <span class="inline-emphasis">rank</span> the best rentals based on your clients needs!</span>
+            </div>
+        {% else %}
+            <div class="info-text"><span>Let us <span class="inline-emphasis">rank</span> the best rentals based on your needs!</span>
+            </div>
+        {% endif %}
+        <div class="icon-container">
+            <img class="infographic survey-results" src="{% static 'infographics/vector_ranking.svg' %}">
+        </div>
     </div>
-  </div>
-
-  <div class="info-row">
-    <div class="info-text"><span>Let us <span class="inline-emphasis">rank</span> the best rentals based on your needs!</span>
-    </div>
-    <div class="icon-container">
-      <img class="infographic survey-results" src="{% static 'infographics/vector_ranking.svg' %}">
-    </div>
-  </div>
 
 
-  </div>
+    </div>
 
 
 

--- a/cocoon/survey/cocoon_algorithm/rent_algorithm.py
+++ b/cocoon/survey/cocoon_algorithm/rent_algorithm.py
@@ -115,6 +115,8 @@ class RentAlgorithm(SortingAlgorithms, WeightScoringAlgorithm, PriceAlgorithm, C
 
                 destination_address = destination.full_address
 
+                print(destination.transit_type.transit_type)
+
                 results = distance_matrix_requester.get_durations_and_distances(origin_addresses,
                                                                                 [destination_address],
                                                                                 mode=destination.commute_type.commute_type)

--- a/cocoon/survey/cocoon_algorithm/rent_algorithm.py
+++ b/cocoon/survey/cocoon_algorithm/rent_algorithm.py
@@ -115,12 +115,13 @@ class RentAlgorithm(SortingAlgorithms, WeightScoringAlgorithm, PriceAlgorithm, C
 
                 destination_address = destination.full_address
 
-                print(destination.transit_type.transit_type)
+                transit_option = []
+                transit_option.append(destination.transit_type.transit_type)
 
                 results = distance_matrix_requester.get_durations_and_distances(origin_addresses,
                                                                                 [destination_address],
+                                                                                transit_option=transit_option,
                                                                                 mode=destination.commute_type.commute_type)
-
                 # iterates over min of number to be computed and length of results in case lens don't match
                 for i in range(min(number_of_exact_commutes_computed, len(results))):
                     # update exact commute time with in minutes

--- a/cocoon/survey/cocoon_algorithm/rent_algorithm.py
+++ b/cocoon/survey/cocoon_algorithm/rent_algorithm.py
@@ -116,7 +116,8 @@ class RentAlgorithm(SortingAlgorithms, WeightScoringAlgorithm, PriceAlgorithm, C
                 destination_address = destination.full_address
 
                 transit_option = []
-                transit_option.append(destination.transit_type.transit_type)
+                for item in destination.transit_type.all():
+                    transit_option.append(str(item))
 
                 results = distance_matrix_requester.get_durations_and_distances(origin_addresses,
                                                                                 [destination_address],

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -1,4 +1,4 @@
-# Django modules
+ # Django modules
 from django import forms
 from django.forms import ModelForm
 from django.utils.text import slugify

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -287,13 +287,12 @@ class CommuteInformationForm(ModelForm):
     transit_type = forms.ModelChoiceField(
         queryset=TransitType.objects.all(),
         label="Transit Type",
-        widget=forms.SelectMultiple(
+        widget=forms.Select(
             attrs={
                 'class': 'form-control'
             }
         ),
     )
-
     class Meta:
         model = CommuteInformationModel
         fields = '__all__'

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -284,10 +284,10 @@ class CommuteInformationForm(ModelForm):
         ),
     )
 
-    transit_type = forms.ModelChoiceField(
+    transit_type = forms.ModelMultipleChoiceField(
         queryset=TransitType.objects.all(),
         label="Transit Type",
-        widget=forms.Select(
+        widget=forms.SelectMultiple(
             attrs={
                 'class': 'form-control'
             }

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -153,10 +153,6 @@ class RentSurveyForm(ExteriorAmenitiesForm, PriceInformationForm,
 
 class BrokerRentSurveyForm(RentSurveyForm):
 
-    def __init__(self, *args, **kwargs):
-        self.user = kwargs.pop('user', None)
-        super(BrokerRentSurveyForm, self).__init__(*args, **kwargs)
-
     provider = forms.ModelMultipleChoiceField(
         widget=forms.SelectMultiple(
             attrs={

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -138,6 +138,11 @@ class RentSurveyForm(ExteriorAmenitiesForm, PriceInformationForm,
     """
     Rent Survey is the rent survey on the main survey page
     """
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        super(RentSurveyForm, self).__init__(*args, **kwargs)
+
     class Meta:
         model = RentingSurveyModel
         # Make sure to set the name later, in the survey result if they want to save the result
@@ -148,6 +153,10 @@ class RentSurveyForm(ExteriorAmenitiesForm, PriceInformationForm,
 
 class BrokerRentSurveyForm(RentSurveyForm):
 
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        super(BrokerRentSurveyForm, self).__init__(*args, **kwargs)
+
     provider = forms.ModelMultipleChoiceField(
         widget=forms.SelectMultiple(
             attrs={
@@ -156,12 +165,43 @@ class BrokerRentSurveyForm(RentSurveyForm):
         queryset=HomeProviderModel.objects.all()
     )
 
+    name = forms.CharField(
+        label="Clients Name",
+        initial=DEFAULT_RENT_SURVEY_NAME,
+        widget=forms.TextInput(
+            attrs={
+                'class': 'form-control',
+                'placeholder': 'Enter the name of the survey',
+            }),
+        max_length=MAX_TEXT_INPUT_LENGTH,
+    )
+
+    def is_valid(self):
+        valid = super(BrokerRentSurveyForm, self).is_valid()
+
+        if not valid:
+            return valid
+
+        # Need to make a copy because otherwise when an error is added, that field
+        # is removed from the cleaned_data, then any subsequent checks of that field
+        # will cause a key error
+        current_form = self.cleaned_data.copy()
+
+        # Since slugs need to be unique and the survey name generates the slug, make sure that the new slug
+        #   will not conflict with a current survey. If it does, force them to choose a new name.
+        if 'name' in self.changed_data:
+            if self.user.userProfile.rentingsurveymodel_set.filter(url=slugify(current_form['name'])).exists():
+                self.add_error('name', "You already have a very similar name, please choose a more unique name")
+                valid = False
+
+        return valid
+
     class Meta:
         model = RentingSurveyModel
         # Make sure to set the name later, in the survey result if they want to save the result
         fields = ["num_bedrooms", "max_bathrooms", "min_bathrooms", "home_type",
                   "max_price", "desired_price", "price_weight",
-                  "parking_spot", "provider"]
+                  "parking_spot", "provider", "name"]
 
 
 class RentSurveyFormMini(ExteriorAmenitiesForm, PriceInformationForm,
@@ -211,23 +251,6 @@ class RentSurveyFormMini(ExteriorAmenitiesForm, PriceInformationForm,
         fields = ["num_bedrooms", "max_bathrooms", "min_bathrooms", "home_type",
                   "max_price", "desired_price", "price_weight",
                   "parking_spot", "name"]
-
-
-class BrokerRentSurveyFormMini(RentSurveyFormMini):
-
-    provider = forms.ModelMultipleChoiceField(
-        widget=forms.SelectMultiple(
-            attrs={
-                'class': 'form-control',
-            }),
-        queryset=HomeProviderModel.objects.all()
-    )
-
-    class Meta:
-        model = RentingSurveyModel
-        fields = ["num_bedrooms", "max_bathrooms", "min_bathrooms", "home_type",
-                  "max_price", "desired_price", "price_weight",
-                  "parking_spot", "name", 'provider', ]
 
 
 class CommuteInformationForm(ModelForm):

--- a/cocoon/survey/forms.py
+++ b/cocoon/survey/forms.py
@@ -7,7 +7,7 @@ from django.utils.text import slugify
 from cocoon.survey.models import RentingSurveyModel, HomeInformationModel, CommuteInformationModel, \
     RentingDestinationsModel, PriceInformationModel, ExteriorAmenitiesModel, DestinationsModel
 from cocoon.houseDatabase.models import HomeTypeModel, HomeProviderModel
-from cocoon.commutes.models import CommuteType
+from cocoon.commutes.models import CommuteType, TransitType
 
 # Python global configurations
 from config.settings.Global_Config import MAX_TEXT_INPUT_LENGTH, MAX_NUM_BEDROOMS, DEFAULT_RENT_SURVEY_NAME, \
@@ -278,6 +278,16 @@ class CommuteInformationForm(ModelForm):
         queryset=CommuteType.objects.all(),
         label="Commute Type",
         widget=forms.Select(
+            attrs={
+                'class': 'form-control'
+            }
+        ),
+    )
+
+    transit_type = forms.ModelChoiceField(
+        queryset=TransitType.objects.all(),
+        label="Transit Type",
+        widget=forms.SelectMultiple(
             attrs={
                 'class': 'form-control'
             }

--- a/cocoon/survey/models.py
+++ b/cocoon/survey/models.py
@@ -180,7 +180,7 @@ class CommuteInformationModel(models.Model):
     min_commute = models.IntegerField()
     commute_weight = models.IntegerField()
     commute_type = models.ForeignKey(CommuteType)
-    transit_type = models.ForeignKey(TransitType)
+    transit_type = models.ForeignKey(TransitType, null=True)
 
     @property
     def commute_range(self):

--- a/cocoon/survey/models.py
+++ b/cocoon/survey/models.py
@@ -8,7 +8,7 @@ import math
 # Import cocoon models
 from cocoon.userAuth.models import UserProfile
 from cocoon.houseDatabase.models import HomeTypeModel, HomeProviderModel
-from cocoon.commutes.models import CommuteType
+from cocoon.commutes.models import CommuteType, TransitType
 
 # Import Global Variables
 from config.settings.Global_Config import MAX_NUM_BATHROOMS, DEFAULT_RENT_SURVEY_NAME, \
@@ -180,6 +180,7 @@ class CommuteInformationModel(models.Model):
     min_commute = models.IntegerField()
     commute_weight = models.IntegerField()
     commute_type = models.ForeignKey(CommuteType)
+    transit_type = models.ForeignKey(TransitType)
 
     @property
     def commute_range(self):

--- a/cocoon/survey/models.py
+++ b/cocoon/survey/models.py
@@ -180,7 +180,7 @@ class CommuteInformationModel(models.Model):
     min_commute = models.IntegerField()
     commute_weight = models.IntegerField()
     commute_type = models.ForeignKey(CommuteType)
-    transit_type = models.ForeignKey(TransitType, null=True)
+    transit_type = models.ManyToManyField(TransitType, null=True)
 
     @property
     def commute_range(self):

--- a/cocoon/survey/templates/survey/helpers/commuter_form.html
+++ b/cocoon/survey/templates/survey/helpers/commuter_form.html
@@ -33,7 +33,7 @@
 <div class="form-group">
     {% comment %}
         This form-group contains the rentingdestination model form. This form group includes the functionality to adding
-            a dynamic amount of coummters. There are a couple key functions.
+        a dynamic amount of coummters. There are a couple key functions.
             1. Tabs are used to seperate commuters and clicking on the different tabs loads the different commuters
             2. There is a plug and minus tab which is able to add and remove commuters from the list.
     {% endcomment %}
@@ -116,7 +116,7 @@
                         {% endif %}
                 <br>
                 {{ form.as_table }}
-                </div>
+                 </div>
             {% endfor %}
         </div>
     </div>

--- a/cocoon/survey/templates/survey/rentingSurvey.html
+++ b/cocoon/survey/templates/survey/rentingSurvey.html
@@ -86,7 +86,6 @@
                         <div class="form-group step_div">
                             {% include "survey/helpers/commuter_form.html" %}
                             <br>
-                            <span class="help-block">Currently the Commute time, weight and type are for all the commutes</span>
                         </div>
                         <br>
 

--- a/cocoon/survey/templates/survey/rentingSurvey.html
+++ b/cocoon/survey/templates/survey/rentingSurvey.html
@@ -42,6 +42,11 @@
                         <span class="help-block">All fields are required. Each item will be an important factor which will filter the items</span>
                         <div class="form-group step_div">
                             <div class="form-group">
+                                {{ form.name.label_tag }}
+                                {{ form.name }}
+                                {{ form.name.errors }}
+                            </div>
+                            <div class="form-group">
                                 {{ form.num_bedrooms.label_tag }}
                                 {{ form.num_bedrooms }}
                                 {{ form.num_bedrooms.errors }}

--- a/cocoon/survey/templates/survey/rentingSurvey.html
+++ b/cocoon/survey/templates/survey/rentingSurvey.html
@@ -91,14 +91,6 @@
 
                         {% comment %} Accordion ONLY will have questions that do not need to be validated {% endcomment %}
                         <h3>Amenities</h3>
-                        <p class="help-block">Nothing below is required but it tailors the search to your needs!
-                            <span class="glyphicon glyphicon-info-sign"  data-toggle="tooltip"
-                                  data-placement="left" title="For the following questions, a weight of zero means the question has no effect.
-                                    Increasing weight means homes with that element will be given increasing preference and homes
-                                    without that item will be given decreased preference.
-                                    A weight of the max value means the home must have that item.">
-
-                            </span></p>
                         <div class="form-group">
                             <div class="panel-group" id="accordion">
                                 <div class="panel panel-default">

--- a/cocoon/survey/views.py
+++ b/cocoon/survey/views.py
@@ -19,7 +19,7 @@ from cocoon.userAuth.models import UserProfile
 # Import Survey algorithm modules
 from cocoon.survey.cocoon_algorithm.rent_algorithm import RentAlgorithm
 from cocoon.survey.models import RentingSurveyModel, RentingDestinationsModel
-from cocoon.survey.forms import RentSurveyForm, BrokerRentSurveyForm, BrokerRentSurveyFormMini, \
+from cocoon.survey.forms import RentSurveyForm, BrokerRentSurveyForm, \
     RentingDestinationsForm, RentSurveyFormMini
 
 
@@ -52,7 +52,7 @@ def renting_survey(request):
 
     if request.method == 'POST':
         # create a form instance and populate it with data from the request:
-        form = form_type(request.POST)
+        form = form_type(request.POST, user=request.user)
 
         # check whether it is valid
         if form.is_valid():
@@ -180,7 +180,7 @@ def survey_result_rent(request, survey_url=""):
     user_profile = get_object_or_404(UserProfile, user=request.user)
 
     if user_profile.user.is_broker:
-        form_type = BrokerRentSurveyFormMini
+        form_type = BrokerRentSurveyForm
     else:
         form_type = RentSurveyFormMini
 

--- a/cocoon/templates/base.html
+++ b/cocoon/templates/base.html
@@ -53,7 +53,13 @@
                 </ul>
                 <ul class="nav navbar-nav">
                     {% if user.is_authenticated %}
-                        {% block nav-mysurvies %}<li><a class="link" href="{% url 'userAuth:user_surveys' %}">My Surveys</a></li>{% endblock %}
+                        {% block nav-mysurvies %}
+                        {% if is_broker %}
+                            <li><a class="link" href="{% url 'userAuth:user_surveys' %}">Client Surveys</a></li>
+                        {% else %}
+                            <li><a class="link" href="{% url 'userAuth:user_surveys' %}">My Surveys</a></li>
+                        {% endif %}
+                        {% endblock %}
                         {% block nav-visitlist %}<li><a class="link" href="{% url 'survey:visitList' %}">Favorites</a></li>{% endblock %}
                         {% block nav-contact %}<li><a class="link" id="rightmost-nav-item" href="{% url 'homePage:about' %}">About Us</a></li>{% endblock %}
                     {% endif %}

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -14,7 +14,7 @@ from django.core.wsgi import get_wsgi_application
 from django.core.exceptions import ImproperlyConfigured
 
 # Opens the secrets file and loads the values
-with open(os.path.expanduser("~") + '/work/Cocoon/config/settings/secrets.json') as f:
+with open(os.path.expanduser("~") + '/Desktop/Cocoon/config/settings/secret.json') as f:
         secrets = json.loads(f.read())
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,7 +54,7 @@ Setting up Software
         ::
 
                 cd ~/work/Cocoon/config/settings
-                cp secret.json.template secret.json
+                cp secrets.json.template secret.json
 
 Creating the Postgres Database
 ------------------------------


### PR DESCRIPTION
Currently the functionality allows for users to pick both transit modes (bus, subway, train) and also commute types (driving, walking, biking). I think these should both be available because you may not always want to drive/walk/bike but at the same time you might want flexibility in your commute choices. By having the transit modes appear only after "transit" is selected in commute type, you're narrowing down the list of valid homes. 