### PR TITLE
Issue 202 move foreign key

### DIFF
--- a/cocoon/scheduler/admin.py
+++ b/cocoon/scheduler/admin.py
@@ -4,16 +4,16 @@ from .models import ItineraryModel
 # Register your models here.
 
 
-class ItineraryAdmin(admin.ModelAdmin):
-    fieldsets = [
-        ('Client',
-         {'fields': ('client', 'homes')}
-         ),
-        ('Tour',
-         {'fields': ('itinerary', 'tour_duration_seconds', 'available_start_times')}),
-        ('Agent',
-         {'fields': ('agent', 'selected_start_time')})
-    ]
-
-
-admin.site.register(ItineraryModel, ItineraryAdmin)
+# class ItineraryAdmin(admin.ModelAdmin):
+#     fieldsets = [
+#         ('Client',
+#          {'fields': ('client', 'homes')}
+#          ),
+#         ('Tour',
+#          {'fields': ('itinerary', 'tour_duration_seconds', 'available_start_times')}),
+#         ('Agent',
+#          {'fields': ('agent', 'selected_start_time')})
+#     ]
+#
+#
+# admin.site.register(ItineraryModel, ItineraryAdmin)

--- a/cocoon/scheduler/admin.py
+++ b/cocoon/scheduler/admin.py
@@ -1,19 +1,31 @@
 from django.contrib import admin
 from .models import ItineraryModel
+from .models import TimeModel
 
 # Register your models here.
 
+class TimeInline(admin.StackedInline):
+    model = TimeModel
+    extra = 0
 
-# class ItineraryAdmin(admin.ModelAdmin):
-#     fieldsets = [
-#         ('Client',
-#          {'fields': ('client', 'homes')}
-#          ),
-#         ('Tour',
-#          {'fields': ('itinerary', 'tour_duration_seconds', 'available_start_times')}),
-#         ('Agent',
-#          {'fields': ('agent', 'selected_start_time')})
-#     ]
-#
-#
-# admin.site.register(ItineraryModel, ItineraryAdmin)
+class ItineraryAdmin(admin.ModelAdmin):
+    fieldsets = [
+        ('Client',
+         {'fields': ('client', 'homes')}
+         ),
+        ('Tour',
+         {'fields': ('itinerary', 'tour_duration_seconds')}),
+        ('Agent',
+         {'fields': ('agent', 'selected_start_time')})
+    ]
+
+    inlines = [TimeInline]
+
+class TimeAdmin(admin.ModelAdmin):
+    fieldsets = [
+        ('Time',
+         {'fields': ('time', 'itinerary')}),
+    ]
+
+admin.site.register(ItineraryModel, ItineraryAdmin)
+admin.site.register(TimeModel, TimeAdmin)

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -15,10 +15,10 @@ class TimeModel(models.Model):
             self.itinerary (ForeignKey) -> The associated itinerary
     """
     time = models.DateTimeField(default=timezone.now)
-    itinerary = models.ForeignKey('ItineraryModel', related_name='start_times', on_delete=models.PROTECT, blank=False, null=False)
+    itinerary = models.ForeignKey('ItineraryModel', related_name='start_times', on_delete=models.CASCADE, blank=False, null=False)
 
     def __str__(self):
-        return self.time
+        return str(self.time)
 
 
 class ItineraryModel(models.Model):
@@ -36,9 +36,9 @@ class ItineraryModel(models.Model):
     """
     client = models.ForeignKey(MyUser, related_name='my_tours', on_delete=models.CASCADE)
     itinerary = models.FileField(blank=True)
-    agent = models.ForeignKey(MyUser, related_name='scheduled_tours', on_delete=models.CASCADE, blank=True, null=True)
+    agent = models.ForeignKey(MyUser, related_name='scheduled_tours', on_delete=models.SET_NULL, blank=True, null=True)
     tour_duration_seconds = models.IntegerField(default=0)
-    selected_start_time = models.OneToOneField('TimeModel', on_delete=models.CASCADE, blank=True, null=True)
+    selected_start_time = models.OneToOneField('TimeModel', on_delete=models.SET_NULL, blank=True, null=True)
     homes = models.ManyToManyField(RentDatabaseModel, blank=True)
 
     def __str__(self):

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -7,7 +7,15 @@ from cocoon.houseDatabase.models import RentDatabaseModel
 
 
 class TimeModel(models.Model):
+    """
+        Model for a proposed itinerary start time.
+
+        Attributes:
+            self.time (DateTimeField) -> The available start time proposed by the client
+            self.itinerary (ForeignKey) -> The associated itinerary
+    """
     time = models.DateTimeField(default=timezone.now)
+    itinerary = models.ForeignKey('ItineraryModel', related_name='start_times', on_delete=models.PROTECT, blank=False, null=False)
 
     def __str__(self):
         return self.time
@@ -24,16 +32,13 @@ class ItineraryModel(models.Model):
            self.agent: (ForeignKey('MyUser') -> The agent that will be conducting the tour for the client
            self.tour_duration_seconds: (IntegerField) -> The tour duration stored in seconds
            self.selected_start_time (OneToOneField) -> Stores the selected time that the agent selected for the tour
-           self.available_start_times (ForeignKey) -> Stores the avaiable times that the user can go on a tour
            self.homes (ManytoManyField) -> Stores the homes that are associated with this itinerary
     """
     client = models.ForeignKey(MyUser, related_name='my_tours', on_delete=models.CASCADE)
     itinerary = models.FileField(blank=True)
     agent = models.ForeignKey(MyUser, related_name='scheduled_tours', on_delete=models.CASCADE, blank=True, null=True)
     tour_duration_seconds = models.IntegerField(default=0)
-    selected_start_time = models.OneToOneField(TimeModel, on_delete=models.CASCADE, blank=True, null=True)
-    available_start_times = models.ForeignKey(TimeModel, related_name='start_times', on_delete=models.CASCADE,
-                                              null=True, blank=True)
+    selected_start_time = models.OneToOneField('TimeModel', on_delete=models.CASCADE, blank=True, null=True)
     homes = models.ManyToManyField(RentDatabaseModel, blank=True)
 
     def __str__(self):


### PR DESCRIPTION
## Overview of changes

This PR removes `ForeignKey(TimeModel)`, replacing it with the `TimeModel` field, `ForeignKey(ItineraryModel)`.

This was necessary because we have **many** TimeModel's to **one** ItineraryModel. 

I also changed a couple `on_delete`s. We should be able to delete the agent and selected start time without cascading that to the itinerary itself (another agent could pick up the tours, or a new start time could be selected)

#### Note:
This type of PR cannot be merged automatically. In the future, we should have a protocol for updating the db schema to minimize downtime, but here I think it should suffice to delete the scheduler migrations and DROP the available_start_times column from `scheduler_itinerarymodel`.