### PR TITLE
Itinerary File Additions

### DIFF
--- a/cocoon/houseDatabase/admin.py
+++ b/cocoon/houseDatabase/admin.py
@@ -26,6 +26,8 @@ class HouseAdmin(admin.ModelAdmin):
              'listing_office',
              'listing_number',
              'remarks',
+             'showing_instructions',
+             'showing_remarks',
          )}
         ),
     ]

--- a/cocoon/houseDatabase/management/commands/mls_rets/MLSRetsRequester.py
+++ b/cocoon/houseDatabase/management/commands/mls_rets/MLSRetsRequester.py
@@ -2,6 +2,7 @@
 from django.utils import timezone
 from django.db import IntegrityError
 from django.core.exceptions import ValidationError
+from django.db.utils import DataError
 
 # Python Imports
 from rets import Session
@@ -111,6 +112,8 @@ class MLSRetsRequester(object):
             new_listing.listing_agent = home['ListAgentMlsId']
             new_listing.listing_office = home['ListOfficeMlsId']
             new_listing.listing_provider = HomeProviderModel.objects.get_or_create(provider=HomeProviderModel.MLSPIN)[0]
+            new_listing.showing_instructions = home['ShowingInstructions']
+            new_listing.showing_remarks = home['FIRM_RMK1']
 
             # Amenities
             new_listing.dogs_allowed = 'yes' in home['PETS_ALLOWED'].lower()

--- a/cocoon/houseDatabase/models.py
+++ b/cocoon/houseDatabase/models.py
@@ -191,7 +191,10 @@ class HouseManagementModel(UpdateBase, models.Model):
     listing_number = models.IntegerField(default=-1)  # The id of the home
     listing_provider = models.ForeignKey(HomeProviderModel)
     listing_agent = models.CharField(max_length=200, default="", blank=True)
+    listing_agent_phone = models.CharField(max_length=200, default="", blank=True)
     listing_office = models.CharField(max_length=200, default="", blank=True)  # The listing office, i.e William Raveis
+    showing_instructions = models.TextField(default="", blank=True)
+    showing_remarks = models.TextField(default="", blank=True)
     last_updated = models.DateField(default=timezone.now)
 
     def update(self, update_model):

--- a/cocoon/scheduler/admin.py
+++ b/cocoon/scheduler/admin.py
@@ -1,7 +1,11 @@
 from django.contrib import admin
 from .models import ItineraryModel
 from .models import TimeModel
+from .models import HomeVisitModel
 
+class VisitInline(admin.StackedInline):
+    model = HomeVisitModel
+    extra = 0
 
 
 class TimeInline(admin.StackedInline):
@@ -15,7 +19,14 @@ class ItineraryAdmin(admin.ModelAdmin):
     search_fields = ('client__email',)
     list_filter = ['client', 'finished', ]
 
-    inlines = [TimeInline]
+    inlines = [VisitInline, TimeInline]
+
+
+class VisitAdmin(admin.ModelAdmin):
+    fieldsets = [
+        ('Home',
+         {'fields': ('home', 'travel_time', 'visit_index')}),
+    ]
 
 
 class TimeAdmin(admin.ModelAdmin):
@@ -27,3 +38,4 @@ class TimeAdmin(admin.ModelAdmin):
 
 admin.site.register(ItineraryModel, ItineraryAdmin)
 admin.site.register(TimeModel, TimeAdmin)
+admin.site.register(HomeVisitModel, VisitAdmin)

--- a/cocoon/scheduler/clientScheduler/base_algorithm.py
+++ b/cocoon/scheduler/clientScheduler/base_algorithm.py
@@ -1,3 +1,6 @@
+# import python modules
+import math
+
 class clientSchedulerAlgorithm:
 
 
@@ -13,7 +16,7 @@ class clientSchedulerAlgorithm:
         :return: (int): starting_point - the Global Minimum. This is the smallest possible distance, so the algorithm will start
         from this address
         '''
-        min_time = 1000000
+        min_time = math.inf
         starting_point = -1
         for i in range(len(homes_matrix)):
             for j in range(len(homes_matrix[0])):
@@ -41,7 +44,7 @@ class clientSchedulerAlgorithm:
         while (len(shortest_path) != len(homes_matrix)):
             self.edge_weights.append(local_min)
             shortest_path.append(global_minimum)
-            local_min = 10000000
+            local_min = math.inf
             global_min_temp = global_minimum
             for i in range(len(homes_matrix[global_min_temp])):
                 if i not in shortest_path:

--- a/cocoon/scheduler/clientScheduler/base_algorithm.py
+++ b/cocoon/scheduler/clientScheduler/base_algorithm.py
@@ -9,7 +9,7 @@ class clientSchedulerAlgorithm:
         Find the global minimum of the homes_matrix, basically by just finding the smallest point in the matrix and
         returning its index
         :param homes_matrix: The matrix calcualted using DistanceWrapper() with distances between every pair of homes in
-        favorited list
+        visit list
         :return: (int): starting_point - the Global Minimum. This is the smallest possible distance, so the algorithm will start
         from this address
         '''
@@ -17,7 +17,7 @@ class clientSchedulerAlgorithm:
         starting_point = -1
         for i in range(len(homes_matrix)):
             for j in range(len(homes_matrix[0])):
-                if homes_matrix[i][j] < min_time and homes_matrix[i][j] != 0:
+                if homes_matrix[i][j] < min_time and i != j:
                     min_time = homes_matrix[i][j]
                     starting_point = i
 

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -130,8 +130,7 @@ class ClientScheduler(clientSchedulerAlgorithm):
         """
         Algorithm runner
         args:
-        :param: (list) homes_list: The matrix calculated using DistanceWrapper() with distances between every pair
-                                    of homes in visit list
+        :param: (list) homes_list: The list of homes, whose pairwise distances will be calculated
         """
 
         shortest_path = self.run_client_scheduler_algorithm(homes_list)

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -68,7 +68,6 @@ class ClientScheduler(clientSchedulerAlgorithm):
         return homes_matrix
 
     def run_client_scheduler_algorithm(self, homes_list):
-
         """
         Creates the home matrix and calls the calculation algorithm to find the shortest path
         args:

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -105,8 +105,8 @@ class ClientScheduler(clientSchedulerAlgorithm):
     def save_itinerary(self, homes_list, user, survey):
         """
 
-        :param: (list) homes_list: The matrix calculated using DistanceWrapper() with distances between every pair
-                                    of homes in visit list
+        :param: (list) homes_list: List of RentDatabaseModel's relevant to the itinerary. Typically sourced from an
+        itinerary visit list
         :param: (request.user) user: user
         :return: (boolean) -> True: The itinerary was created successfully
                               False: The itinerary was not created
@@ -119,8 +119,6 @@ class ClientScheduler(clientSchedulerAlgorithm):
                 itinerary_model.tour_duration_seconds = total_time_secs
                 itinerary_model.survey = survey
                 itinerary_model.save()
-
-                ordered_visit_list = [home_distance[0]]
 
                 # Add 20 minutes to each home
                 for home in homes_list:

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -88,21 +88,16 @@ class ClientScheduler(clientSchedulerAlgorithm):
         Creates the home matrix and calls the calculation algorithm to find the shortest path
         args:
         :param homes_list: List of RentDatabaseModel objects from which shortest path will be deduced
-        :return: (list): shortest_path List of indices that denote the shortest path, which is the output of the
-            algorithms
+        :return: (list (home, time)): Ordered list of tuples containing the next home to visit on the tour and the
+        driving time to that home (seconds) to that home from the previous (First entry takes 0 time)
         """
 
         homes_matrix = self.build_homes_matrix(homes_list)
         shortest_path = self.calculate_path(homes_matrix)
+        ordered_homes = [homes_list[i] for i in shortest_path]
         edge_weights = self.get_edge_weights()
 
-        tuple_list_edges = []
-
-        for i in range(len(shortest_path)):
-            temp_tuple = (shortest_path[i], edge_weights[i])
-            tuple_list_edges.append(temp_tuple)
-
-        return tuple_list_edges
+        return list(zip(ordered_homes, edge_weights))
 
     def save_itinerary(self, homes_list, user, survey):
         """

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -102,7 +102,7 @@ class ClientScheduler(clientSchedulerAlgorithm):
                 itinerary_model.survey = survey
                 itinerary_model.save()
 
-                for (home, time), i in enumerate(home_time_tour):
+                for i, (home, time) in enumerate(home_time_tour):
                     home_visit, created = HomeVisitModel.objects.get_or_create(
                         home=home,
                         itinerary=itinerary_model,
@@ -128,4 +128,4 @@ class ClientScheduler(clientSchedulerAlgorithm):
             total_time_secs = 20 * 60 + time + total_time_secs
 
         # File name is unique based on user and current time (making it impossible to have duplicates)
-        return total_time_secs, home_time_tour
+        return (total_time_secs, home_time_tour)

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -24,7 +24,6 @@ class ClientScheduler(clientSchedulerAlgorithm):
     def __init__(self, accuracy=CommuteAccuracy.EXACT):
         super().__init__()
         self.commute_accuracy = accuracy
-        self.home_time_tours = []
 
     def build_homes_matrix(self, homes_list):
         """
@@ -96,16 +95,16 @@ class ClientScheduler(clientSchedulerAlgorithm):
             itinerary = ItineraryModel.objects.get(client=user)
             start_times = itinerary.start_times
 
-            for start_time in start_times:
+            for start_time in start_times.all():
                 elapsed_time = 0
-                for home_visit in HomeVisitModel.objects.filter(itinerary=itinerary).order_by("visit_index"):
+                for home_visit in HomeVisitModel.objects.filter(itinerary=itinerary).order_by("visit_index").all():
                     if home_visit.visit_index is not 0:
                         elapsed_time += 20 * 60
                     elapsed_time += home_visit.travel_time
                     time_slot = start_time.time + timedelta(seconds=elapsed_time)
                     _ = ViableTourTimeModel.objects.get_or_create(
                         home_visit=home_visit,
-                        time=time_slot)
+                        visit_time=time_slot)
             return True
         return False
 

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -25,8 +25,9 @@ class ClientScheduler(clientSchedulerAlgorithm):
         """
         builds the homes matrix using the DistanceWrapper for now. Basically computes the distances using the Google Distance Matrix API and stores it.
 
-        :param (list) homes_list: List of strings containing home addresses used to compute the optimal itinerary
-        :return: (list): homes_matrix a nxn matrix of distances found using the DistanceWrapper() to indicate the distances betweeen any two homes
+        :param (list) homes_list: List of RentDatabaseModel objects included in the homes matrix
+        :return: (list) homes_matrix: a square matrix of travel times found using the DistanceWrapper() indicating pairwise home distances,
+        where the row and column indices are preserved from the input order
         """
 
         # Matrix that contains every home and the duration it takes to get to every other home in the list
@@ -48,6 +49,8 @@ class ClientScheduler(clientSchedulerAlgorithm):
                     distance_meters = commute[0][1]
                     if time_seconds is not None and distance_meters is not None:
                         home_distances.append(time_seconds)
+                    else:
+                        home_distances.append(-1)
             else:
                 update_commutes_cache_client_scheduler(homes_list,
                                                        home,
@@ -84,8 +87,7 @@ class ClientScheduler(clientSchedulerAlgorithm):
         """
         Creates the home matrix and calls the calculation algorithm to find the shortest path
         args:
-        :param homes_list: The matrix calculated using DistanceWrapper() with distances between every pair of homes in
-            favourited list
+        :param homes_list: List of RentDatabaseModel objects from which shortest path will be deduced
         :return: (list): shortest_path List of indices that denote the shortest path, which is the output of the
             algorithms
         """
@@ -130,7 +132,7 @@ class ClientScheduler(clientSchedulerAlgorithm):
         """
         Algorithm runner
         args:
-        :param: (list) homes_list: The list of homes, whose pairwise distances will be calculated
+        :param: (list) homes_list: The list of RentDatabaseModel objects, whose pairwise distances will be calculated
         """
 
         shortest_path = self.run_client_scheduler_algorithm(homes_list)

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -120,6 +120,8 @@ class ClientScheduler(clientSchedulerAlgorithm):
                 itinerary_model.survey = survey
                 itinerary_model.save()
 
+                ordered_visit_list = [home_distance[0]]
+
                 # Add 20 minutes to each home
                 for home in homes_list:
                     itinerary_model.homes.add(home)

--- a/cocoon/scheduler/clientScheduler/client_scheduler.py
+++ b/cocoon/scheduler/clientScheduler/client_scheduler.py
@@ -92,7 +92,7 @@ class ClientScheduler(clientSchedulerAlgorithm):
         :return: True for success, False for failure
         """
         if ItineraryModel.retrieve_unfinished_itinerary(user).exists():
-            itinerary = ItineraryModel.objects.get(client=user)
+            itinerary = ItineraryModel.objects.exclude(finished=True).get(client=user)
             start_times = itinerary.start_times
 
             for start_time in start_times.all():

--- a/cocoon/scheduler/clientScheduler/tests/test_client_scheduler_wrapper.py
+++ b/cocoon/scheduler/clientScheduler/tests/test_client_scheduler_wrapper.py
@@ -5,6 +5,24 @@ from cocoon.commutes.constants import CommuteAccuracy
 
 class TestClientScheduler(TestCase):
 
+    def interpret_algorithm_output(self, homes_list, shortest_path):
+
+        """
+        Utility function to interpret the shortest path using the home list to make it ready for output onto the main site
+        args:
+        :param (list) homes_list: The matrix calcualted using DistanceWrapper() with distances between every pair of homes in favorited list
+        :param (list) shortest_path: List of indices that denote the shortest path, which is the output of the algorithm
+        :return: (list): interpreted_route List of strings containing the addresses in order of the shortest possible path, human readable
+        """
+
+        interepreted_route = []
+
+        for item in shortest_path:
+
+            interepreted_route.append((homes_list[item[0]], item[1]))
+
+        return interepreted_route
+
     def setUp(self):
         self.clientScheduler = ClientScheduler(accuracy=CommuteAccuracy.EXACT)
 
@@ -105,7 +123,7 @@ class TestClientScheduler(TestCase):
         mock_edge_weights.return_value = [0,5,3]
 
         tuple_list = self.clientScheduler.run_client_scheduler_algorithm(homes_list)
-        self.assertEqual(tuple_list, [(1,0),(2,5),(0,3)])
+        self.assertEqual(tuple_list, [("home2",0),("home3",5),("home1",3)])
 
     def test_interpret_algorithm_output_increasing(self):
         '''
@@ -115,7 +133,7 @@ class TestClientScheduler(TestCase):
 
         homes_list = ["home1", "home2", "home3"]
         shortest_path = [(0,0), (1,2), (2,3)]
-        interpreted_route = self.clientScheduler.interpret_algorithm_output(homes_list, shortest_path)
+        interpreted_route = self.interpret_algorithm_output(homes_list, shortest_path)
         self.assertEqual(interpreted_route, [("home1",0), ("home2",2), ("home3",3)])
 
     def test_interpret_algorithm_output_decreasing(self):
@@ -126,7 +144,7 @@ class TestClientScheduler(TestCase):
 
         homes_list = ["home1", "home2", "home3"]
         shortest_path = [(2,0), (1,2), (0,1)]
-        interpreted_route = self.clientScheduler.interpret_algorithm_output(homes_list, shortest_path)
+        interpreted_route = self.interpret_algorithm_output(homes_list, shortest_path)
         self.assertEqual(interpreted_route, [("home3",0), ("home2",2), ("home1",1)])
 
     def test_interpret_algorithm_output_random(self):
@@ -137,5 +155,5 @@ class TestClientScheduler(TestCase):
 
         homes_list = ["home1", "home2", "home3"]
         shortest_path = [(1,0),(0,1),(2,3)]
-        interpreted_route = self.clientScheduler.interpret_algorithm_output(homes_list, shortest_path)
+        interpreted_route = self.interpret_algorithm_output(homes_list, shortest_path)
         self.assertEqual(interpreted_route, [("home2",0), ("home1",1), ("home3",3)])

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -243,7 +243,7 @@ class HomeVisitModel(models.Model):
     """
     home = models.ForeignKey(RentDatabaseModel, on_delete=models.CASCADE)
     itinerary = models.ForeignKey(ItineraryModel, related_name="homes", on_delete=models.CASCADE)
-    time_to_successor = models.IntegerField(default=null, null=True)
+    time_to_successor = models.IntegerField(default=None, null=True)
     visit_number = models.IntegerField()
 
 class TimeModel(models.Model):

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -37,6 +37,7 @@ class ItineraryModel(models.Model):
     agent = models.ForeignKey(MyUser, related_name='scheduled_tours', on_delete=models.SET_NULL, blank=True, null=True)
     tour_duration_seconds = models.IntegerField(default=0)
     selected_start_time = models.DateTimeField(default=None, blank=True, null=True)
+    homes = models.ManyToManyField(RentDatabaseModel, blank=True)
     finished = models.BooleanField(default=False)
     url = models.SlugField(max_length=100, unique=True)
 
@@ -242,9 +243,9 @@ class HomeVisitModel(models.Model):
         Model wrapper around RentDatabase
     """
     home = models.ForeignKey(RentDatabaseModel, on_delete=models.CASCADE)
-    itinerary = models.ForeignKey(ItineraryModel, related_name="homes", on_delete=models.CASCADE)
+    itinerary = models.ForeignKey(ItineraryModel, related_name="ordered_homes", on_delete=models.CASCADE)
     travel_time = models.IntegerField(default=None, null=True)
-    visit_number = models.IntegerField()
+    visit_index = models.IntegerField()
 
 class TimeModel(models.Model):
     """

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -260,7 +260,7 @@ class ViableTourTimeModel(models.Model):
 
     """
     home_visit = models.ForeignKey(HomeVisitModel, related_name="viable_times", on_delete=models.CASCADE)
-    time = models.DateTimeField
+    visit_time = models.DateTimeField(default=None)
 
     UNAVAILABLE = "n"
     AVAILABLE = "y"
@@ -272,7 +272,7 @@ class ViableTourTimeModel(models.Model):
     )
 
     availability = models.CharField(
-        unique=True,
+        unique=False,
         choices=AVAILABILITY,
         default=UNDETERMINED,
         max_length=1,

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -260,7 +260,7 @@ class ViableTourTimeModel(models.Model):
 
     """
     home_visit = models.ForeignKey(HomeVisitModel, related_name="viable_times", on_delete=models.CASCADE)
-    visit_time = models.DateTimeField(default=None)
+    visit_time = models.DateTimeField(default=timezone.now)
 
     UNAVAILABLE = "n"
     AVAILABLE = "y"

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -243,7 +243,7 @@ class HomeVisitModel(models.Model):
     """
     home = models.ForeignKey(RentDatabaseModel, on_delete=models.CASCADE)
     itinerary = models.ForeignKey(ItineraryModel, related_name="homes", on_delete=models.CASCADE)
-    time_to_successor = models.IntegerField(default=None, null=True)
+    travel_time = models.IntegerField(default=None, null=True)
     visit_number = models.IntegerField()
 
 class TimeModel(models.Model):

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -253,7 +253,7 @@ class HomeVisitModel(models.Model):
     visit_index = models.IntegerField()
 
 
-class ViableTourTime(models.Model):
+class ViableTourTimeModel(models.Model):
     """
         Model for a potentially viable tour slot, deduced from a client's availabilities and the distance between
         homes on a tour.

--- a/cocoon/scheduler/models.py
+++ b/cocoon/scheduler/models.py
@@ -31,14 +31,12 @@ class ItineraryModel(models.Model):
            self.agent: (ForeignKey('MyUser') -> The agent that will be conducting the tour for the client
            self.tour_duration_seconds: (IntegerField) -> The tour duration stored in seconds
            self.selected_start_time (OneToOneField) -> Stores the selected time that the agent selected for the tour
-           self.homes (ManytoManyField) -> Stores the homes that are associated with this itinerary
     """
     client = models.ForeignKey(MyUser, related_name='my_tours', on_delete=models.CASCADE)
     survey = models.ForeignKey(RentingSurveyModel, related_name='itinerary', on_delete=models.SET_NULL, null=True)
     agent = models.ForeignKey(MyUser, related_name='scheduled_tours', on_delete=models.SET_NULL, blank=True, null=True)
     tour_duration_seconds = models.IntegerField(default=0)
     selected_start_time = models.DateTimeField(default=None, blank=True, null=True)
-    homes = models.ManyToManyField(RentDatabaseModel, blank=True)
     finished = models.BooleanField(default=False)
     url = models.SlugField(max_length=100, unique=True)
 
@@ -239,6 +237,14 @@ class ItineraryModel(models.Model):
         # send confirmation email to user
         email.send()
 
+class HomeVisitModel(models.Model):
+    """
+        Model wrapper around RentDatabase
+    """
+    home = models.ForeignKey(RentDatabaseModel, on_delete=models.CASCADE)
+    itinerary = models.ForeignKey(ItineraryModel, related_name="homes", on_delete=models.CASCADE)
+    time_to_successor = models.IntegerField(default=null, null=True)
+    visit_number = models.IntegerField()
 
 class TimeModel(models.Model):
     """

--- a/cocoon/scheduler/serializers.py
+++ b/cocoon/scheduler/serializers.py
@@ -50,20 +50,16 @@ class ItinerarySerializer(serializers.HyperlinkedModelSerializer):
 
 class HomeVisitSerializer(serializers.HyperlinkedModelSerializer):
 
-    home = RentDatabaseSerializer(read_only=True)
-    itinerary = ItinerarySerializer(read_only=True)
     travel_time = serializers.IntegerField(read_only=True)
     visit_index = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = HomeVisitModel
-        fields = ('id', 'home', 'itinerary', 'travel_time', 'visit_index')
+        fields = ('id', 'travel_time', 'visit_index')
 
 
 class ViableTourTimeSerializer(serializers.HyperlinkedModelSerializer):
-    home_visit = HomeVisitSerializer(read_only=False)
-    visit_time = serializers.DateTimeField(read_only=True)
 
     class Meta:
         model = ViableTourTimeModel
-        fields = ('id', 'home_visit', 'visit_time', 'availability')
+        fields = ('id', 'availability')

--- a/cocoon/scheduler/serializers.py
+++ b/cocoon/scheduler/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from .models import ItineraryModel
 from .models import TimeModel
 from .models import ViableTourTimeModel
+from .models import HomeVisitModel
 
 # Import Third party modules
 from cocoon.userAuth.serializers import MyUserSerializer
@@ -16,12 +17,6 @@ class TimeModelSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = TimeModel
         fields = ('id', 'time', 'time_available_seconds')
-
-
-class ViableTourTimeSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = ViableTourTimeModel
-        fields = ('id', 'visit_time', 'availability')
 
 
 class ItinerarySerializer(serializers.HyperlinkedModelSerializer):
@@ -51,3 +46,24 @@ class ItinerarySerializer(serializers.HyperlinkedModelSerializer):
                   'tour_duration_seconds', 'selected_start_time', 'homes',
                   'is_claimed', 'is_scheduled', 'start_times', 'is_pending', 'finished', 'hash',
                   'url')
+
+
+class HomeVisitSerializer(serializers.HyperlinkedModelSerializer):
+
+    home = RentDatabaseSerializer(read_only=True)
+    itinerary = ItinerarySerializer(read_only=True)
+    travel_time = serializers.IntegerField(read_only=True)
+    visit_index = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = HomeVisitModel
+        fields = ('id', 'home', 'itinerary', 'travel_time', 'visit_index')
+
+
+class ViableTourTimeSerializer(serializers.HyperlinkedModelSerializer):
+    home_visit = HomeVisitSerializer(read_only=False)
+    visit_time = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = ViableTourTimeModel
+        fields = ('id', 'home_visit', 'visit_time', 'availability')

--- a/cocoon/scheduler/serializers.py
+++ b/cocoon/scheduler/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 # Import App modules
 from .models import ItineraryModel
 from .models import TimeModel
+from .models import ViableTourTimeModel
 
 # Import Third party modules
 from cocoon.userAuth.serializers import MyUserSerializer
@@ -15,6 +16,12 @@ class TimeModelSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = TimeModel
         fields = ('id', 'time', 'time_available_seconds')
+
+
+class ViableTourTimeSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = ViableTourTimeModel
+        fields = ('id', 'visit_time', 'availability')
 
 
 class ItinerarySerializer(serializers.HyperlinkedModelSerializer):

--- a/cocoon/scheduler/static/scheduler/css/itineraryFile.css
+++ b/cocoon/scheduler/static/scheduler/css/itineraryFile.css
@@ -167,6 +167,12 @@ table > tbody > tr > td.glyphicon-remove {
 }
 
 #listing-number-button:hover {
+    border-bottom: none;
+    color: var(--black);
+    margin-bottom: 1px;
+}
+
+#listing-number-button:hover {
     cursor: pointer;
 }
 

--- a/cocoon/scheduler/static/scheduler/css/itineraryFile.css
+++ b/cocoon/scheduler/static/scheduler/css/itineraryFile.css
@@ -14,7 +14,7 @@ table {
     max-width: 700px;
 }
 
-.itinerary-home-table {
+.itinerary-home-table-wrapper {
     margin: 50px auto;
 }
 
@@ -26,7 +26,7 @@ table {
     justify-content: space-between;
 }
 
-.home-list-container.horizontal > table {
+.home-list-container.horizontal > .itinerary-home-table-wrapper {
     min-width: 600px;
     margin: 40px 40px;
 }
@@ -111,9 +111,8 @@ table > tbody > tr > td:nth-child(even) {
 }
 
 table > thead > tr > th {
-    font-size: 14px;
+    font-size: 16px;
     font-weight: bold;
-    text-decoration: underline;
     padding: 8px;
     text-align: left;
     position: relative;

--- a/cocoon/scheduler/static/scheduler/css/itineraryFile.css
+++ b/cocoon/scheduler/static/scheduler/css/itineraryFile.css
@@ -47,12 +47,12 @@ table {
     border-radius: 50%;
 }
 
-.map-link, .mail-link, .listing-agent-link {
+.map-link, .mail-link, .listing-agent-link, .survey-link {
     text-decoration: underline;
     color: var(--teal);
 }
 
-.map-link:visited, .mail-link:visited, listing-agent-link:visited {
+.map-link:visited, .mail-link:visited, listing-agent-link:visited, survey-link:visited {
     text-decoration: underline;
     color: var(--grey);
 }

--- a/cocoon/scheduler/static/scheduler/css/itineraryFile.css
+++ b/cocoon/scheduler/static/scheduler/css/itineraryFile.css
@@ -156,6 +156,20 @@ table > tbody > tr > td.glyphicon-remove {
     color: red;
 }
 
+#listing-number-button {
+    background: none !important;
+    border: none;
+    padding: 0 !important;
+    font: inherit;
+    border-bottom: 1px solid var(--teal);
+    cursor: pointer;
+    color: var(--teal);
+}
+
+#listing-number-button:hover {
+    cursor: pointer;
+}
+
 .expand-button {
     display: block;
     width: 100%;

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -188,7 +188,13 @@
                 </tr>
                 <tr>
                     <td class="left header">Listing No.</td>
-                    <td class="right">{{ home.listing_number|listing_to_link:home.listing_provider.provider}}</td>
+                    <td class="right">
+                        {% if home.listing_provider.provider == "MLSPIN" %}
+                            <button id="listing-number-button" onclick="copyAndRedirect({{ home.listing_number }})">{{ home.listing_number }}</button>
+                        {% elif home.listing_provider.provider == "YGL"%}
+                            <a href="{{ home.listing_number|listing_to_ygl }}">{{ home.listing_number }}</a>
+                        {% endif %}
+                    </td>
                 </tr>
                 <tr>
                     <td class="left header">Agent ID</td>
@@ -210,11 +216,11 @@
                     <td class="right">{{ home.listing_office }}</td>
                 </tr>
                 <tr>
-                    <td class="left header">Showing Instructions</td>
+                    <td class="left header">Showing instructions</td>
                     <td class="right">[ insert showing instructions ]</td>
                 </tr>
                 <tr>
-                    <td class="left header">Office ID</td>
+                    <td class="left header">Showing remarks</td>
                     <td class="right">[ insert showing remarks ]</td>
                 </tr>
                 <tr>
@@ -352,6 +358,22 @@
     function horizontalLayout() {
         $(".home-list-container").addClass('horizontal');
         $(".home-list-container").removeClass('vertical');
+    }
+
+    function copyAndRedirect(listingNumber) {
+
+        var tempInput = document.createElement("input");
+        tempInput.style = "position: absolute; left: -1000px; top: -1000px";
+        tempInput.value = listingNumber;
+        document.body.appendChild(tempInput);
+        tempInput.select();
+        document.execCommand("copy");
+        document.body.removeChild(tempInput);
+
+        alert("Copied listing ID, redirecting to MLSPIN search...");
+        setTimeout(function(){
+            window.open('https://h3v.mlspin.com/MLS.Pinergy/Search/Main/Index', '_blank');
+        }, 1000);
     }
 
 </script>

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -4,276 +4,321 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>{% block title %}Cocoon | {{ client.first_name }}'s Itinerary{% endblock %}</title>
-  <link href="{% static 'scheduler/css/itineraryFile.css' %}" rel="stylesheet" type="text/css" media="screen, print">
-  <link href="{% static 'cocoon/main/css/base.css' %}" rel="stylesheet" type="text/css" media="screen, print">
-  <!-- JQuery CDN -->
-  <script
-          src="https://code.jquery.com/jquery-2.2.4.js"
-          integrity="sha256-iT6Q9iMJYuQiMWNd9lDyBUStIq/8PuOW33aOqmvFpqI="
-          crossorigin="anonymous"></script>
-  <!-- Font Styles -->
-  <link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Oswald" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=PT+Sans+Narrow" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Pacifico" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Montserrat:600,700,800" rel="stylesheet">
+    <title>{% block title %}Cocoon | {{ client.first_name }}'s Itinerary{% endblock %}</title>
+    <link href="{% static 'scheduler/css/itineraryFile.css' %}" rel="stylesheet" type="text/css" media="screen, print">
+    <link href="{% static 'cocoon/main/css/base.css' %}" rel="stylesheet" type="text/css" media="screen, print">
+    <!-- JQuery CDN -->
+    <script
+            src="https://code.jquery.com/jquery-2.2.4.js"
+            integrity="sha256-iT6Q9iMJYuQiMWNd9lDyBUStIq/8PuOW33aOqmvFpqI="
+            crossorigin="anonymous"></script>
+    <!-- Font Styles -->
+    <link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans|Oswald" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=PT+Sans+Narrow" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Pacifico" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:600,700,800" rel="stylesheet">
 
 
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta charset="UTF-8">
-  <meta name="theme-color" content="#A13718" />
-  <link rel="stylesheet" href="{% static 'bootstrap-3.4.0-custom/css/bootstrap.css' %}">
-  <link href="{% static 'cocoon/main/css/base.css' %}" rel="stylesheet">
-  <link rel="shortcut icon" type="image/png" href="{% static 'homePage/cocoon_logo.png' %}"/>
-  <link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8">
+    <meta name="theme-color" content="#A13718"/>
+    <link rel="stylesheet" href="{% static 'bootstrap-3.4.0-custom/css/bootstrap.css' %}">
+    <link href="{% static 'cocoon/main/css/base.css' %}" rel="stylesheet">
+    <link rel="shortcut icon" type="image/png" href="{% static 'homePage/cocoon_logo.png' %}"/>
+    <link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet">
 
 </head>
 <p class="absolute-logo">Cocoon</p>
-  <body>
-    <table class="client-information-table" id="client-information-table">
-      <thead>
-        <tr>
-          <th colspan="2">
-            Client Information
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td class="left header">Client Name</td>
-          <td class="right">{{ client.full_name|try_string:"-" }}</td>
-        </tr>
-        <tr>
-          <td class="left header">Phone Number</td>
-          <td class="right">
+<body>
+<table class="client-information-table" id="client-information-table">
+    <thead>
+    <tr>
+        <th colspan="2">
+            CLIENT INFORMATION
+        </th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td class="left header">Client Name</td>
+        <td class="right">{{ client.full_name|try_string:"-" }}</td>
+    </tr>
+    <tr>
+        <td class="left header">Phone Number</td>
+        <td class="right">
             <a href="tel:{{ client.phone_number }}">{{ client.phone_numner|try_string:"-" }}</a>
-          </td>
-        </tr>
-        <tr>
-            <td class="left header">Email Address</td>
-            <td class="right"><a class="mail-link" href="mailto:{{ client.email }}">{{ client.email }}</a></td>
-        </tr>
-        {% for d in destinations %}
-          {% if d != "" %}
-             <tr>
-              <td class="left header">Destination Address {{ forloop.counter }}</td>
-              <td class="right">{{ d|try_string:"-" }}</td>
-          </tr>
-          {% endif %}
-        {% endfor %}
-        <tr>
-            <td class="left header">Tour Duration</td>
-            <td class="right">{{ tour_duration|try_string:"-" }}</td>
-        </tr>
-        <tr>
-            <td class="left header">No. of Tenants</td>
-            <td class="right">{{ survey.number_of_tenants|try_string:"not specified"}}</td>
-        </tr>
-        <tr>
-            <td class="left header">Minimum Bedrooms</td>
-            <td class="right">{{ survey.num_bedrooms|try_string:"not specified" }}</td>
-        </tr>
-{#        <tr>#}
-{#            <td class="left header">Bathroom Range</td>#}
-{#            <td class="right">{{ survey.min_bathrooms }} - {{ survey.max_bathrooms }}</td>#}
-{#        </tr>#}
-        <tr>
-            <td class="left header">Price Range</td>
-            <td class="right">{{ survey.price_range|try_string:"not specified" }}</td>
-        </tr>
+        </td>
+    </tr>
+    <tr>
+        <td class="left header">Email Address</td>
+        <td class="right"><a class="mail-link" href="mailto:{{ client.email }}">{{ client.email }}</a></td>
+    </tr>
+    {% for d in destinations %}
+        {% if d != "" %}
+            <tr>
+                <td class="left header">Destination Address {{ forloop.counter }}</td>
+                <td class="right">{{ d|try_string:"-" }}</td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+    <tr>
+        <td class="left header">Tour Duration</td>
+        <td class="right">{{ tour_duration|try_string:"-" }}</td>
+    </tr>
+    <tr>
+        <td class="left header">No. of Tenants</td>
+        <td class="right">{{ survey.number_of_tenants|try_string:"not specified" }}</td>
+    </tr>
+    <tr>
+        <td class="left header">Minimum Bedrooms</td>
+        <td class="right">{{ survey.num_bedrooms|try_string:"not specified" }}</td>
+    </tr>
+    <tr>
+        <td class="left header">Price Range</td>
+        <td class="right">{{ survey.price_range|try_string:"not specified" }}</td>
+    </tr>
 
-        {# Rows below are hidden by default#}
-        <tr class="extra-client-info hidden">
-            <td class="left header">Hardwood floors</td>
-            <td class="right glyphicon {% condition survey.wants_hardwood_floors "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">AC</td>
-            <td class="right glyphicon {% condition survey.wants_AC "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Dishwasher</td>
-            <td class="right glyphicon {% condition survey.wants_dishwasher "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Laundry in building</td>
-            <td class="right glyphicon {% condition survey.wants_laundry_in_building "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Laundry in unit</td>
-            <td class="right glyphicon {% condition survey.wants_laundry_in_unit "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-{#        <tr class="extra-client-info hidden">#}
-{#            <td class="left header">Parking</td>#}
-{#            <td class="right glyphicon {% condition survey.wants_parking "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>#}
-{#        </tr>#}
-{#        <tr class="extra-client-info hidden">#}
-{#            <td class="left header">No. parking spots</td>#}
-{#            <td class="right">{{ survey.number_of_cars }}</td>#}
-{#        </tr>#}
-        <tr class="extra-client-info hidden">
-            <td class="left header">Patio</td>
-            <td class="right glyphicon {% condition survey.wants_patio "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Pool</td>
-            <td class="right glyphicon {% condition survey.wants_pool "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Gym</td>
-            <td class="right glyphicon {% condition survey.wants_gym "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Storage</td>
-            <td class="right glyphicon {% condition survey.wants_storage "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Number of dogs</td>
-            <td class="right">{{ survey.number_of_dogs }}</td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Service dogs</td>
-            <td class="right glyphicon {% condition survey.service_dogs "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Dogs Size</td>
-            <td class="right"> {{ survey.dog_size|try_string:"-" }} </td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Breed of dogs</td>
-            <td class="right">{{ survey.breed_of_dogs|try_string:"-" }}</td>
-        </tr>
-        <tr class="extra-client-info hidden">
-            <td class="left header">Cats</td>
-            <td class="right glyphicon {% condition survey.wants_cats "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-        </tr>
-      </tbody>
-    </table>
-    <span type="button" id="expand-client-info-button" class="expand-button" onclick="showMoreDetails()">more</span>
+    {# Rows below are hidden by default#}
+    <tr class="extra-client-info hidden">
+        <td class="left header">Hardwood floors</td>
+        <td class="right glyphicon {% condition survey.wants_hardwood_floors "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">AC</td>
+        <td class="right glyphicon {% condition survey.wants_AC "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Dishwasher</td>
+        <td class="right glyphicon {% condition survey.wants_dishwasher "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Laundry in building</td>
+        <td class="right glyphicon {% condition survey.wants_laundry_in_building "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Laundry in unit</td>
+        <td class="right glyphicon {% condition survey.wants_laundry_in_unit "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    {#        <tr class="extra-client-info hidden">#}
+    {#            <td class="left header">Parking</td>#}
+    {#            <td class="right glyphicon {% condition survey.wants_parking "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>#}
+    {#        </tr>#}
+    {#        <tr class="extra-client-info hidden">#}
+    {#            <td class="left header">No. parking spots</td>#}
+    {#            <td class="right">{{ survey.number_of_cars }}</td>#}
+    {#        </tr>#}
+    <tr class="extra-client-info hidden">
+        <td class="left header">Patio</td>
+        <td class="right glyphicon {% condition survey.wants_patio "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Pool</td>
+        <td class="right glyphicon {% condition survey.wants_pool "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Gym</td>
+        <td class="right glyphicon {% condition survey.wants_gym "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Storage</td>
+        <td class="right glyphicon {% condition survey.wants_storage "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Number of dogs</td>
+        <td class="right">{{ survey.number_of_dogs }}</td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Service dogs</td>
+        <td class="right glyphicon {% condition survey.service_dogs "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Dogs Size</td>
+        <td class="right"> {{ survey.dog_size|try_string:"-" }} </td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Breed of dogs</td>
+        <td class="right">{{ survey.breed_of_dogs|try_string:"-" }}</td>
+    </tr>
+    <tr class="extra-client-info hidden">
+        <td class="left header">Cats</td>
+        <td class="right glyphicon {% condition survey.wants_cats "glyphicon-ok" "glyphicon-remove" %}"
+            aria-hidden="true"></td>
+    </tr>
+    </tbody>
+</table>
+<span type="button" id="expand-client-info-button" class="expand-button" onclick="showMoreDetails()">more</span>
 
-    <div class="layout-buttons" role="group" aria-label="...">
-      <button onclick="verticalLayout()" type="button" class="vertical-button">Vertical</button>
-      <button onclick="horizontalLayout()" type="button" class="horizontal-button">Horizontal</button>
-    </div>
+<div class="layout-buttons" role="group" aria-label="...">
+    <button onclick="verticalLayout()" type="button" class="vertical-button">Vertical</button>
+    <button onclick="horizontalLayout()" type="button" class="horizontal-button">Horizontal</button>
+</div>
 
-    <div class="home-list-container">
+<div class="home-list-container">
 
     {% for home in homes %}
 
-      <table class="itinerary-home-table" id="itinerary-home-table-{{ forloop.counter }}">
-        <thead>
-          <tr>
-            <th class="left header home-table-count-col"><span class="home-table-count">{{ forloop.counter }}</span></th>
-            <th class="right">
-              <a target="_blank" class="map-link" href="{{ home.full_address|gmaps_from_address }}">{{ home.full_address }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="left header">Price</td>
-            <td class="right">{% replace home.price "-1" "-" %}</td>
-          </tr>
-          <tr>
-            <td class="left header">Currently available</td>
-            <td class="right glyphicon {% condition home.on_market "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">Listing provider</td>
-            <td class="right">{{ home.listing_provider.provider }}</td>
-          </tr>
-          <tr>
-            <td class="left header">Date available</td>
-            <td class="right">{{ home.date_available }}</td>
-          </tr>
-          <tr>
-            <td class="left header">Listing Agent</td>
-            <td class="right">
-              
-              {% if home.listing_provider.provider == 'MLSPIN' %}
-                <a class="listing-agent-link" target="_blank" href="{{ home.listing_agent|agent_to_link:home.listing_provider.provider }}">{{ home.listing_agent|try_string:"-" }}</a>
-              {% else %}
-                {{ home.listing_agent|try_string:"-" }}
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <td class="left header">Listing No.</td>
-            <td class="right">{{ home.listing_number }}</td>
-          </tr>
-          <tr>
-            <td class="left header">Listing remarks</td>
-            <td class="right listing-remarks">{{ home.remarks }}</td>
-          </tr>
-          <tr>
-            <td class="left header">Number of bathrooms</td>
-            <td class="right">{{ home.num_bathrooms }}</td>
-          </tr>
-          <tr>
-            <td class="left header">Number of bedrooms</td>
-            <td class="right">{{ home.num_bedrooms }}</td>
-          </tr>
-          <tr>
-            <td class="left header">Furnished</td>
-            <td class="right glyphicon {% condition home.furnished "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">Hardwood floors</td>
-            <td class="right glyphicon {% condition home.hardwood_floors "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">AC</td>
-            <td class="right glyphicon {% condition home.air_conditioning "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">Allows dogs</td>
-            <td class="right glyphicon {% condition home.dogs_allowed "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">Allows cats</td>
-            <td class="right glyphicon {% condition home.cats_allowed "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">In-unit laundry</td>
-            <td class="right glyphicon {% condition home.laundry_in_unit "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">In-building landury</td>
-            <td class="right glyphicon {% condition home.laundry_in_building "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-{#          <tr>#}
-{#            <td class="left header">Parking spot</td>#}
-{#            <td class="right glyphicon {% condition home.parking_spot "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>#}
-{#          </tr>#}
-          <tr>
-            <td class="left header">Pool</td>
-            <td class="right glyphicon {% condition home.pool "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">Patio / Balcony</td>
-            <td class="right glyphicon {% condition home.patio_balcony "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">Gym</td>
-            <td class="right glyphicon {% condition home.gym "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-          <tr>
-            <td class="left header">Storage</td>
-            <td class="right glyphicon {% condition home.storage "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>
-          </tr>
-        </tbody>
-      </table>
+        <div class="itinerary-home-table-wrapper">
+            <table class="itinerary-home-table" id="itinerary-home-table-{{ forloop.counter }}">
+                <thead>
+                <tr>
+                    <th class="left header home-table-count-col"><span
+                            class="home-table-count">{{ forloop.counter }}</span></th>
+                    <th class="right">
+                        <a target="_blank" class="map-link"
+                           href="{{ home.full_address|gmaps_from_address }}">{{ home.full_address }}</a>
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td class="left header">Price</td>
+                    <td class="right">${% replace home.price "-1" "-" %}</td>
+                </tr>
+                <tr>
+                    <td class="left header">Listing No.</td>
+                    <td class="right">{{ home.listing_number }}</td>
+                </tr>
+                <tr>
+                    <td class="left header">Agent ID</td>
+                    <td class="right">
+                        {% if home.listing_provider.provider == 'MLSPIN' %}
+                            <a class="listing-agent-link" target="_blank"
+                               href="{{ home.listing_agent|agent_to_link:home.listing_provider.provider }}">{{ home.listing_agent|try_string:"-" }}</a>
+                        {% else %}
+                            {{ home.listing_agent|try_string:"-" }}
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
+                    <td class="left header">Agent Cell</td>
+                    <td class="right">[ insert phone number ]</td>
+                </tr>
+                <tr>
+                    <td class="left header">Office ID</td>
+                    <td class="right">{{ home.listing_office }}</td>
+                </tr>
+                <tr>
+                    <td class="left header">Showing Instructions</td>
+                    <td class="right">[ insert showing instructions ]</td>
+                </tr>
+                <tr>
+                    <td class="left header">Office ID</td>
+                    <td class="right">[ insert showing remarks ]</td>
+                </tr>
+                <tr>
+                    <td class="left header">Currently available</td>
+                    <td class="right glyphicon {% condition home.on_market "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr>
+                    <td class="left header">Listing provider</td>
+                    <td class="right">{{ home.listing_provider.provider }}</td>
+                </tr>
+
+                {# Fields below are hidden by default#}
+
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Date available</td>
+                    <td class="right">{{ home.date_available }}</td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Listing remarks</td>
+                    <td class="right listing-remarks">{{ home.remarks }}</td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Number of bathrooms</td>
+                    <td class="right">{{ home.num_bathrooms }}</td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Number of bedrooms</td>
+                    <td class="right">{{ home.num_bedrooms }}</td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Furnished</td>
+                    <td class="right glyphicon {% condition home.furnished "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Hardwood floors</td>
+                    <td class="right glyphicon {% condition home.hardwood_floors "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">AC</td>
+                    <td class="right glyphicon {% condition home.air_conditioning "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Allows dogs</td>
+                    <td class="right glyphicon {% condition home.dogs_allowed "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Allows cats</td>
+                    <td class="right glyphicon {% condition home.cats_allowed "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">In-unit laundry</td>
+                    <td class="right glyphicon {% condition home.laundry_in_unit "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">In-building landury</td>
+                    <td class="right glyphicon {% condition home.laundry_in_building "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                {#          <tr>#}
+                {#            <td class="left header">Parking spot</td>#}
+                {#            <td class="right glyphicon {% condition home.parking_spot "glyphicon-ok" "glyphicon-remove" %}" aria-hidden="true"></td>#}
+                {#          </tr>#}
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Pool</td>
+                    <td class="right glyphicon {% condition home.pool "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Patio / Balcony</td>
+                    <td class="right glyphicon {% condition home.patio_balcony "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Gym</td>
+                    <td class="right glyphicon {% condition home.gym "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                <tr class="extra-home-info hidden">
+                    <td class="left header">Storage</td>
+                    <td class="right glyphicon {% condition home.storage "glyphicon-ok" "glyphicon-remove" %}"
+                        aria-hidden="true"></td>
+                </tr>
+                </tbody>
+            </table>
+            <span type="button" id="expand-home-info-button-{{ forloop.counter }}" class="expand-button"
+                  onclick="showMoreHomeInfo({{ forloop.counter }})">more</span>
+        </div>
 
     {% endfor %}
 
-    </div>
-  </body>
+</div>
+</body>
 
-  <script>
+<script>
 
     var extraClientInformationVisibile = false;
+
     function showMoreDetails() {
         if (extraClientInformationVisibile) {
             $('.extra-client-info').addClass('hidden');
@@ -286,6 +331,19 @@
         extraClientInformationVisibile = !extraClientInformationVisibile;
     }
 
+    var extraHomeInformationVisibile = false;
+
+    function showMoreHomeInfo(counter) {
+        if (extraHomeInformationVisibile) {
+            $('#itinerary-home-table-' + counter.toString()).find(".extra-home-info").addClass('hidden');
+            $('#expand-home-info-button-' + counter.toString()).text('more');
+        } else {
+            $('#itinerary-home-table-' + counter.toString()).find(".extra-home-info").removeClass('hidden');
+            $('#expand-home-info-button-' + counter.toString()).text('hide');
+        }
+        extraHomeInformationVisibile = !extraHomeInformationVisibile;
+    }
+
     function verticalLayout() {
         $(".home-list-container").addClass('vertical');
         $(".home-list-container").removeClass('horizontal');
@@ -296,5 +354,5 @@
         $(".home-list-container").removeClass('vertical');
     }
 
-  </script>
+</script>
 </html>

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -84,7 +84,7 @@
     </tr>
     <tr>
         <td class="left header">Survey link</td>
-        <td class="right"><a class="survey-link" href="/survey/rentSurvey/{{ survey.url }}">survey</a></td>
+        <td class="right"><a class="survey-link" href="/survey/rent/{{ survey.url }}">survey</a></td>
     </tr>
 
     {# Rows below are hidden by default#}

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -32,6 +32,7 @@
 </head>
 <p class="absolute-logo">Cocoon</p>
 <body>
+
 <table class="client-information-table" id="client-information-table">
     <thead>
     <tr>
@@ -167,7 +168,7 @@
 
 <div class="home-list-container">
 
-    {% for home in homes %}
+    {% for visit in home_visits %}
 
         <div class="itinerary-home-table-wrapper">
             <table class="itinerary-home-table" id="itinerary-home-table-{{ forloop.counter }}">
@@ -177,33 +178,71 @@
                             class="home-table-count">{{ forloop.counter }}</span></th>
                     <th class="right">
                         <a target="_blank" class="map-link"
-                           href="{{ home.full_address|gmaps_from_address }}">{{ home.full_address }}</a>
+                           href="{{ visit.home.full_address|gmaps_from_address }}">{{ visit.home.full_address }}</a>
                     </th>
                 </tr>
                 </thead>
                 <tbody>
                 <tr>
+                    <td colspan="2">
+                        <table class="inner-time-table">
+                            <thead>
+                                <th>Time</th>
+                                <th class="right">Avail.</th>
+                            </thead>
+                            <tbody>
+                            {% for visit in visit_times|index:visit.visit_index %}
+                    <tr>
+                        <td>{{ visit.visit_time }}</td>
+                        <td class="right">
+                            <form action="/scheduler/api/visitTime/" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="pk" value="{{ visit.id }}">
+                                <select name="availability">
+                                    <option {% if visit.availability == "y" %} selected="selected" {% endif %}
+                                                                               value="y">available
+                                    </option>
+                                    <option {% if visit.availability == "n" %} selected="selected" {% endif %}
+                                                                               value="n">unavailable
+                                    </option>
+                                    <option {% if visit.availability == "m" %} selected="selected" {% endif %}
+                                                                               value="m">undetermined
+                                    </option>
+                                </select>
+                                <br><br>
+                                <input type="submit">
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+
+                            </tbody>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
                     <td class="left header">Price</td>
-                    <td class="right">${% replace home.price "-1" "-" %}</td>
+                    <td class="right">${% replace visit.home.price "-1" "-" %}</td>
                 </tr>
                 <tr>
                     <td class="left header">Listing No.</td>
                     <td class="right">
-                        {% if home.listing_provider.provider == "MLSPIN" %}
-                            <button id="listing-number-button" onclick="copyAndRedirect({{ home.listing_number }})">{{ home.listing_number }}</button>
-                        {% elif home.listing_provider.provider == "YGL"%}
-                            <a href="{{ home.listing_number|listing_to_ygl }}">{{ home.listing_number }}</a>
+                        {% if visit.home.listing_provider.provider == "MLSPIN" %}
+                            <button id="listing-number-button"
+                                    onclick="copyAndRedirect({{ visit.home.listing_number }})">{{ visit.home.listing_number }}</button>
+                        {% elif visit.home.listing_provider.provider == "YGL" %}
+                            <a href="{{ visit.home.listing_number|listing_to_ygl }}">{{ visit.home.listing_number }}</a>
                         {% endif %}
                     </td>
                 </tr>
                 <tr>
                     <td class="left header">Agent ID</td>
                     <td class="right">
-                        {% if home.listing_provider.provider == 'MLSPIN' %}
+                        {% if visit.home.listing_provider.provider == 'MLSPIN' %}
                             <a class="listing-agent-link" target="_blank"
-                               href="{{ home.listing_agent|agent_to_link:home.listing_provider.provider }}">{{ home.listing_agent|try_string:"-" }}</a>
+                               href="{{ visit.home.listing_agent|agent_to_link:visit.home.listing_provider.provider }}">{{ visit.home.listing_agent|try_string:"-" }}</a>
                         {% else %}
-                            {{ home.listing_agent|try_string:"-" }}
+                            {{ visit.home.listing_agent|try_string:"-" }}
                         {% endif %}
                     </td>
                 </tr>
@@ -213,7 +252,7 @@
                 </tr>
                 <tr>
                     <td class="left header">Office ID</td>
-                    <td class="right">{{ home.listing_office }}</td>
+                    <td class="right">{{ visit.home.listing_office }}</td>
                 </tr>
                 <tr>
                     <td class="left header">Showing instructions</td>
@@ -225,65 +264,65 @@
                 </tr>
                 <tr>
                     <td class="left header">Currently available</td>
-                    <td class="right glyphicon {% condition home.on_market "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.on_market "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr>
                     <td class="left header">Listing provider</td>
-                    <td class="right">{{ home.listing_provider.provider }}</td>
+                    <td class="right">{{ visit.home.listing_provider.provider }}</td>
                 </tr>
 
                 {# Fields below are hidden by default#}
 
                 <tr class="extra-home-info hidden">
                     <td class="left header">Date available</td>
-                    <td class="right">{{ home.date_available }}</td>
+                    <td class="right">{{ visit.home.date_available }}</td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Listing remarks</td>
-                    <td class="right listing-remarks">{{ home.remarks }}</td>
+                    <td class="right listing-remarks">{{ visit.home.remarks }}</td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Number of bathrooms</td>
-                    <td class="right">{{ home.num_bathrooms }}</td>
+                    <td class="right">{{ visit.home.num_bathrooms }}</td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Number of bedrooms</td>
-                    <td class="right">{{ home.num_bedrooms }}</td>
+                    <td class="right">{{ visit.home.num_bedrooms }}</td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Furnished</td>
-                    <td class="right glyphicon {% condition home.furnished "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.furnished "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Hardwood floors</td>
-                    <td class="right glyphicon {% condition home.hardwood_floors "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.hardwood_floors "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">AC</td>
-                    <td class="right glyphicon {% condition home.air_conditioning "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.air_conditioning "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Allows dogs</td>
-                    <td class="right glyphicon {% condition home.dogs_allowed "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.dogs_allowed "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Allows cats</td>
-                    <td class="right glyphicon {% condition home.cats_allowed "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.cats_allowed "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">In-unit laundry</td>
-                    <td class="right glyphicon {% condition home.laundry_in_unit "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.laundry_in_unit "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">In-building landury</td>
-                    <td class="right glyphicon {% condition home.laundry_in_building "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.laundry_in_building "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 {#          <tr>#}
@@ -292,28 +331,28 @@
                 {#          </tr>#}
                 <tr class="extra-home-info hidden">
                     <td class="left header">Pool</td>
-                    <td class="right glyphicon {% condition home.pool "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.pool "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Patio / Balcony</td>
-                    <td class="right glyphicon {% condition home.patio_balcony "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.patio_balcony "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Gym</td>
-                    <td class="right glyphicon {% condition home.gym "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.gym "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 <tr class="extra-home-info hidden">
                     <td class="left header">Storage</td>
-                    <td class="right glyphicon {% condition home.storage "glyphicon-ok" "glyphicon-remove" %}"
+                    <td class="right glyphicon {% condition visit.home.storage "glyphicon-ok" "glyphicon-remove" %}"
                         aria-hidden="true"></td>
                 </tr>
                 </tbody>
             </table>
             <span type="button" id="expand-home-info-button-{{ forloop.counter }}" class="expand-button"
-                  onclick="showMoreHomeInfo({{ forloop.counter }})">more</span>
+                  onclick="showMorevisit.homeInfo({{ forloop.counter }})">more</span>
         </div>
 
     {% endfor %}
@@ -371,7 +410,7 @@
         document.body.removeChild(tempInput);
 
         alert("Copied listing ID, redirecting to MLSPIN search...");
-        setTimeout(function(){
+        setTimeout(function () {
             window.open('https://h3v.mlspin.com/MLS.Pinergy/Search/Main/Index', '_blank');
         }, 1000);
     }

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -188,7 +188,7 @@
                 </tr>
                 <tr>
                     <td class="left header">Listing No.</td>
-                    <td class="right">{{ home.listing_number }}</td>
+                    <td class="right">{{ home.listing_number|listing_to_link:home.listing_provider.provider}}</td>
                 </tr>
                 <tr>
                     <td class="left header">Agent ID</td>

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -49,6 +49,10 @@
         <td class="right">{{ client.full_name|try_string:"-" }}</td>
     </tr>
     <tr>
+        <td class="left header">Load Survey</td>
+        <td class="right"><a class="button btn-primary" href="{{ survey_url }}">Load Survey</a></td>
+    </tr>
+    <tr>
         <td class="left header">Phone Number</td>
         <td class="right">
             <a href="tel:{{ client.phone_number }}">{{ client.phone_numner|try_string:"-" }}</a>
@@ -260,11 +264,11 @@
                 </tr>
                 <tr>
                     <td class="left header">Showing instructions</td>
-                    <td class="right">[ insert showing instructions ]</td>
+                    <td class="right">{{ visit.home.showing_instructions }}</td>
                 </tr>
                 <tr>
                     <td class="left header">Showing remarks</td>
-                    <td class="right">[ insert showing remarks ]</td>
+                    <td class="right">{{ visit.home.showing_remarks }}</td>
                 </tr>
                 <tr>
                     <td class="left header">Currently available</td>

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -191,21 +191,22 @@
                                 <th class="right">Avail.</th>
                             </thead>
                             <tbody>
-                            {% for visit in visit_times|index:visit.visit_index %}
+                            {% for viable_time in visit_times|index:visit.visit_index %}
                     <tr>
-                        <td>{{ visit.visit_time }}</td>
+                        <td>{{ viable_time.visit_time }}</td>
                         <td class="right">
                             <form action="/scheduler/api/visitTime/" method="post">
                                 {% csrf_token %}
-                                <input type="hidden" name="pk" value="{{ visit.id }}">
+                                <input type="hidden" name="id" value="{{ viable_time.id }}">
+                                <input type="hidden" name="home_visit" value="{{ visit.id }}">
                                 <select name="availability">
-                                    <option {% if visit.availability == "y" %} selected="selected" {% endif %}
+                                    <option {% if viable_time.availability == "y" %} selected="selected" {% endif %}
                                                                                value="y">available
                                     </option>
-                                    <option {% if visit.availability == "n" %} selected="selected" {% endif %}
+                                    <option {% if viable_time.availability == "n" %} selected="selected" {% endif %}
                                                                                value="n">unavailable
                                     </option>
-                                    <option {% if visit.availability == "m" %} selected="selected" {% endif %}
+                                    <option {% if viable_time.availability == "m" %} selected="selected" {% endif %}
                                                                                value="m">undetermined
                                     </option>
                                 </select>

--- a/cocoon/scheduler/templates/scheduler/itineraryFile.html
+++ b/cocoon/scheduler/templates/scheduler/itineraryFile.html
@@ -12,6 +12,8 @@
             src="https://code.jquery.com/jquery-2.2.4.js"
             integrity="sha256-iT6Q9iMJYuQiMWNd9lDyBUStIq/8PuOW33aOqmvFpqI="
             crossorigin="anonymous"></script>
+    <script src="{% static 'cocoon/main/ajax/getCookie.js' %}"></script>
+
     <!-- Font Styles -->
     <link href="https://fonts.googleapis.com/css?family=Lobster" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans|Oswald" rel="stylesheet">
@@ -79,6 +81,10 @@
     <tr>
         <td class="left header">Price Range</td>
         <td class="right">{{ survey.price_range|try_string:"not specified" }}</td>
+    </tr>
+    <tr>
+        <td class="left header">Survey link</td>
+        <td class="right"><a class="survey-link" href="/survey/rentSurvey/{{ survey.url }}">survey</a></td>
     </tr>
 
     {# Rows below are hidden by default#}
@@ -195,11 +201,8 @@
                     <tr>
                         <td>{{ viable_time.visit_time }}</td>
                         <td class="right">
-                            <form action="/scheduler/api/visitTime/" method="post">
-                                {% csrf_token %}
-                                <input type="hidden" name="id" value="{{ viable_time.id }}">
-                                <input type="hidden" name="home_visit" value="{{ visit.id }}">
-                                <select name="availability">
+                            <div>
+                                <select id="update-availability-form-{{ viable_time.id }}" name="availability">
                                     <option {% if viable_time.availability == "y" %} selected="selected" {% endif %}
                                                                                value="y">available
                                     </option>
@@ -211,8 +214,8 @@
                                     </option>
                                 </select>
                                 <br><br>
-                                <input type="submit">
-                            </form>
+                                <button onclick="updateAvailability({{ viable_time.id }})">update</button>
+                            </div>
                         </td>
                     </tr>
                 {% endfor %}
@@ -414,6 +417,33 @@
         setTimeout(function () {
             window.open('https://h3v.mlspin.com/MLS.Pinergy/Search/Main/Index', '_blank');
         }, 1000);
+    }
+
+    function updateAvailability(visitId) {
+
+        var newAvail = $("#update-availability-form-" + visitId.toString()).val()
+        console.log(newAvail)
+        $.ajax({
+            type: "post",
+            url: "/scheduler/updateVisitTime/",
+            data: {
+                "id": visitId,
+                "availability": newAvail,
+            },
+
+            success: function (json) {
+                if (json["result"] == 0) {
+                    console.log("Succesfuly updated")
+                } else if (json["result"] == 1) {
+                    console.log("Error updating")
+                }
+            },
+
+            error: function (xhr, errmsg, err) {
+                console.log(xhr.status + ": " + xhr.responseText)
+            }
+        });
+
     }
 
 </script>

--- a/cocoon/scheduler/templatetags/scheduler_extras.py
+++ b/cocoon/scheduler/templatetags/scheduler_extras.py
@@ -35,10 +35,8 @@ def agent_to_link(value, provider):
     if provider == "MLSPIN":
         return "https://h3b.mlspin.com/tools/roster/agent.asp?aid={0}&nomenu=true".format(value)
 
-@register.filter(name="listing_to_link")
+
+@register.filter(name="listing_to_ygl")
 @stringfilter
-def listing_to_link(value, provider):
-    if provider == "MLSPIN":
-        pass
-    elif provider == "YGL":
-        return "https://app.yougotlistings.com/rentals/{0}".format(value)
+def listing_to_ygl(value):
+    return "https://app.yougotlistings.com/rentals/{0}".format(value)

--- a/cocoon/scheduler/templatetags/scheduler_extras.py
+++ b/cocoon/scheduler/templatetags/scheduler_extras.py
@@ -35,6 +35,9 @@ def agent_to_link(value, provider):
     if provider == "MLSPIN":
         return "https://h3b.mlspin.com/tools/roster/agent.asp?aid={0}&nomenu=true".format(value)
 
+@register.filter
+def index(List, i):
+    return List[int(i)]
 
 @register.filter(name="listing_to_ygl")
 @stringfilter

--- a/cocoon/scheduler/templatetags/scheduler_extras.py
+++ b/cocoon/scheduler/templatetags/scheduler_extras.py
@@ -34,3 +34,11 @@ def gmap_from_address(value):
 def agent_to_link(value, provider):
     if provider == "MLSPIN":
         return "https://h3b.mlspin.com/tools/roster/agent.asp?aid={0}&nomenu=true".format(value)
+
+@register.filter(name="listing_to_link")
+@stringfilter
+def listing_to_link(value, provider):
+    if provider == "MLSPIN":
+        pass
+    elif provider == "YGL":
+        return "https://app.yougotlistings.com/rentals/{0}".format(value)

--- a/cocoon/scheduler/urls.py
+++ b/cocoon/scheduler/urls.py
@@ -6,7 +6,7 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 router.register(r'itinerary', views.ItineraryViewset, base_name='itinerary')
-router.register(r'visitTime', views.VisitTimeViewset, base_name='visitTime')
+# router.register(r'visitTime', views.VisitTimeViewset, base_name='visitTime')
 router.register(r'itineraryClient', views.ItineraryClientViewSet, base_name='itineraryClient')
 router.register(r'itineraryAgent', views.ItineraryAgentViewSet, base_name='itineraryAgent')
 router.register(r'itineraryMarket', views.ItineraryMarketViewSet, base_name='itineraryMarket')
@@ -21,6 +21,7 @@ urlpatterns = [
 
     # AJAX requests below
     url(r'^unscheduleItinerary/$', views.unschedule_itinerary, name="unscheduleItinerary"),
+    url(r'^updateVisitTime/$', views.update_visit_time, name="updateVisitTime"),
 
     # Api
     url(r'^api/', include(router.urls))

--- a/cocoon/scheduler/urls.py
+++ b/cocoon/scheduler/urls.py
@@ -6,6 +6,7 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 router.register(r'itinerary', views.ItineraryViewset, base_name='itinerary')
+router.register(r'visitTime', views.VisitTimeViewset, base_name='visitTime')
 router.register(r'itineraryClient', views.ItineraryClientViewSet, base_name='itineraryClient')
 router.register(r'itineraryAgent', views.ItineraryAgentViewSet, base_name='itineraryAgent')
 router.register(r'itineraryMarket', views.ItineraryMarketViewSet, base_name='itineraryMarket')

--- a/cocoon/scheduler/views.py
+++ b/cocoon/scheduler/views.py
@@ -138,25 +138,8 @@ class VisitTimeViewset(viewsets.ModelViewSet):
     """
     Used on the ItineraryFile page to update whether a visit slot is viable after consulting property manager
     """
-
     serializer_class = ViableTourTimeSerializer
-
-    def update(self, request, *args, **kwargs):
-        # Retrieve the itinerary id
-        pk = kwargs.pop('pk', None)
-        availability = kwargs.pop('availability', None)
-        tour_time = get_object_or_404(ViableTourTimeModel, pk=pk)
-        if availability is "y":
-            tour_time.availability = ViableTourTimeModel.AVAILABLE
-        elif availability is "n":
-            tour_time.availability = ViableTourTimeModel.UNAVAILABLE
-        elif availability is "m":
-            tour_time.availability = ViableTourTimeModel.UNDETERMINED
-
-        tour_time = get_object_or_404(ViableTourTimeModel, pk=pk)
-        serializer = ViableTourTimeSerializer(tour_time)
-        return Response(serializer.data)
-
+    queryset = ViableTourTimeModel.objects.all()
 
 class ItineraryViewset(viewsets.ReadOnlyModelViewSet):
     """

--- a/cocoon/scheduler/views.py
+++ b/cocoon/scheduler/views.py
@@ -199,8 +199,8 @@ class ItineraryClientViewSet(viewsets.ModelViewSet):
             homes_list.append(home)
 
         # Run client_scheduler algorithm
-        client_scheduler_alg = ClientScheduler(CommuteAccuracy.EXACT)
-        result = client_scheduler_alg.save_itinerary(homes_list, self.request.user, survey)
+        self.client_scheduler_alg = ClientScheduler(CommuteAccuracy.EXACT)
+        result = self.client_scheduler_alg.save_itinerary(homes_list, self.request.user, survey)
         if result:
             return Response({
                 'result': True,
@@ -234,6 +234,9 @@ class ItineraryClientViewSet(viewsets.ModelViewSet):
                     dt = dateutil.parser.parse(start_time['date'])
                     dt = dt.replace(second=0, microsecond=0)
                     itinerary.start_times.create(time=dt, time_available_seconds=time_available_seconds)
+
+            # Generate potential visit times so agents can coordinate with property managers
+            self.client_scheduler_alg.generate_tour_times(user=user_profile.user)
 
             # Automatically set the agent assigned to the itinerary if the agent has a referred agent
             # Send an email to the appropriate people

--- a/cocoon/scheduler/views.py
+++ b/cocoon/scheduler/views.py
@@ -6,6 +6,7 @@ from django.views.generic import TemplateView
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import user_passes_test
 from django.http import Http404
+from django.contrib.sites.shortcuts import get_current_site
 
 # App Models
 from .models import ItineraryModel, TimeModel, ViableTourTimeModel, HomeVisitModel
@@ -62,6 +63,10 @@ class ItineraryFileView(TemplateView):
 
         start_times = self.itinerary.start_times
 
+        # Survey load url
+        current_site = get_current_site(self.request)
+        survey_load_url = "https://{0}/survey/rent/{1}/".format(current_site.domain, self.itinerary.survey.url)
+
         context.update({
             'client': self.itinerary.client,
             'survey': self.itinerary.survey,
@@ -75,6 +80,7 @@ class ItineraryFileView(TemplateView):
             'is_finished': self.itinerary.finished,
             'visit_times': visit_times,
             "start_times": start_times,
+            "survey_url": survey_load_url,
         })
         return context
 

--- a/cocoon/scheduler/views.py
+++ b/cocoon/scheduler/views.py
@@ -40,6 +40,7 @@ class ItineraryFileView(TemplateView):
     def dispatch(self, request, *args, **kwargs):
         itinerary_slug = kwargs.get('itinerary_slug')
         self.itinerary = get_object_or_404(ItineraryModel, url=itinerary_slug)
+        self.tour_ordered_homes = [visit.home for visit in self.itinerary.ordered_homes.order_by("visit_index")]
         return super(ItineraryFileView, self).dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
@@ -64,7 +65,7 @@ class ItineraryFileView(TemplateView):
             'tour_duration': friendly_duration,
             'is_scheduled': False if self.itinerary.selected_start_time is None else True,
             'start_time': self.itinerary.selected_start_time,
-            'homes': self.itinerary.homes.all(),
+            'homes': self.tour_ordered_homes,
             'is_finished': self.itinerary.finished,
         })
         return context


### PR DESCRIPTION
### Additions to the itinerary file:
1. Stores order of home visits in the db
2. Display order of homes on the itinerary file page is now the actual tour order
3. Hides excess home information on itinerary page by default
4. Generates potential viable tour times for each home based on start times, driving distance between homes, and an assumed 20 minute tour time
5. POST functionality for updating whether time slots are still viable
6. Links to a user's survey from the itinerary file